### PR TITLE
Pin hero card to bottom of image; preserve full background visibility and responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,28 +7,35 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main class="hero" role="main">
-      <section class="hero-card" aria-labelledby="hero-title" aria-describedby="hero-subtitle hero-description">
-        <h1 id="hero-title">BLACK-HIVE</h1>
-        <p id="hero-subtitle" class="hero-subtitle">Tactical Swarm Systems</p>
-        <p id="hero-description" class="hero-description">
-          Precision-coordinated drone intelligence engineered for mission-ready performance in every arena.
-        </p>
-        <div class="cta-group" role="group" aria-label="Primary actions">
-          <a
-            class="cta-button cta-button--primary"
-            href="mailto:ops@black-hive.io"
-            aria-label="Join the BLACK-HIVE waitlist via email"
-          >
-            Join Waitlist
-          </a>
-          <a
-            class="cta-button cta-button--secondary"
-            href="/demo"
-            aria-label="Watch the BLACK-HIVE demo"
-          >
-            Watch Demo
-          </a>
+    <main role="main">
+      <section class="hero" aria-labelledby="hero-title">
+        <div class="hero__bg" aria-hidden="true"></div>
+        <div
+          class="hero__card"
+          aria-labelledby="hero-title"
+          aria-describedby="hero-subtitle hero-description"
+        >
+          <h1 id="hero-title">BLACK-HIVE</h1>
+          <p id="hero-subtitle" class="hero-subtitle">Tactical Swarm Systems</p>
+          <p id="hero-description" class="hero-description">
+            Precision-coordinated drone intelligence engineered for mission-ready performance in every arena.
+          </p>
+          <div class="actions" role="group" aria-label="Primary actions">
+            <a
+              class="cta-button cta-button--primary"
+              href="mailto:ops@black-hive.io"
+              aria-label="Join the BLACK-HIVE waitlist via email"
+            >
+              Join Waitlist
+            </a>
+            <a
+              class="cta-button cta-button--secondary"
+              href="/demo"
+              aria-label="Watch the BLACK-HIVE demo"
+            >
+              Watch Demo
+            </a>
+          </div>
         </div>
       </section>
     </main>

--- a/style.css
+++ b/style.css
@@ -12,30 +12,55 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.35)),
-    url("drone-stadium.jpg") center / cover no-repeat;
+  background-color: #ffffff;
   color: #0f0f0f;
 }
 
-.hero {
+main {
   flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 40px 20px;
 }
 
-.hero-card {
-  background-color: #ffffff;
+.hero {
+  position: relative;
+  min-height: 100vh;
+}
+
+.hero__bg {
+  position: absolute;
+  inset: 0;
+  background: url("drone-stadium.jpg") center / cover no-repeat;
+  z-index: 0;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.15),
+    rgba(0, 0, 0, 0.35) 60%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
+.hero__card {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(clamp(12px, 3vh, 32px) + env(safe-area-inset-bottom, 0px));
+  width: min(680px, calc(100% - 32px));
+  background: #ffffff;
   border-radius: 12px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
-  padding: 40px;
-  max-width: 600px;
-  width: min(100%, 600px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  padding: clamp(20px, 4vw, 40px);
   text-align: center;
+  z-index: 2;
 }
 
-.hero-card h1 {
+.hero__card h1 {
   margin: 0;
   font-size: 36px;
   font-weight: 700;
@@ -55,11 +80,10 @@ body {
   color: #1f1f1f;
 }
 
-.cta-group {
+.actions {
   display: flex;
+  gap: 12px;
   justify-content: center;
-  align-items: center;
-  gap: 16px;
   flex-wrap: wrap;
 }
 
@@ -106,27 +130,22 @@ body {
 }
 
 .page-footer {
-  padding: 16px;
+  margin: 24px 0;
   text-align: center;
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.85);
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+  color: #111111;
 }
 
 @media (max-width: 480px) {
-  .hero {
-    padding: 24px 16px;
-  }
-
-  .hero-card {
+  .hero__card {
     padding: 24px;
   }
 
-  .hero-card h1 {
+  .hero__card h1 {
     font-size: 28px;
   }
 
-  .cta-group {
+  .actions {
     flex-direction: column;
   }
 


### PR DESCRIPTION
## Summary
- restructure the hero section to include a dedicated background layer and a bottom-pinned card while preserving existing content
- add gradient overlay, responsive sizing, and new layout rules to keep the background image fully visible behind the hero card
- update button group spacing and move the footer outside the hero for better separation and readability

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cc7eee61a08325a0ae4f4411e1df33