### PR TITLE
Add overlay BLACK-HIVE SVG logo (top-left of hero) + favicon

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="BH">
+  <polygon points="32,4 58,18 58,46 32,60 6,46 6,18" fill="#cc1e2c"/>
+  <g transform="translate(32,32)">
+    <rect x="-12" y="-2.5" width="24" height="5" rx="2.5" fill="#f0b429"/>
+    <rect x="-2.5" y="-12" width="5" height="24" rx="2.5" fill="#f0b429"/>
+  </g>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="240" height="36" viewBox="0 0 240 36" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="BLACK-HIVE">
+  <title>BLACK-HIVE</title>
+  <g transform="translate(4,2)">
+    <polygon points="16,0 32,9.25 32,27.75 16,37 0,27.75 0,9.25"
+             fill="#14171a" stroke="#cc1e2c" stroke-width="2"/>
+    <g opacity="0.6" stroke="#cc1e2c" stroke-width="1">
+      <polygon points="16,6 24,10.62 24,19.88 16,24.5 8,19.88 8,10.62" fill="#14171a"/>
+      <polygon points="24,10.62 32,15.25 32,24.5 24,29.12 24,19.88" fill="#14171a" opacity="0.6"/>
+      <polygon points="8,10.62 8,19.88 8,19.88 0,24.5 0,15.25 8,10.62" fill="#14171a" opacity="0.6"/>
+    </g>
+    <g id="prop" transform="translate(16,18)">
+      <rect x="-10" y="-2" width="20" height="4" rx="2" fill="#f0b429" opacity="0.95"/>
+      <rect x="-2" y="-10" width="4" height="20" rx="2" fill="#f0b429" opacity="0.95"/>
+    </g>
+  </g>
+  <g transform="translate(56,9)">
+    <text x="0" y="16"
+      font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif"
+      font-size="18" font-weight="800" letter-spacing="1.5" fill="#e8edf2">BLACK-HIVE</text>
+    <rect x="0" y="22" width="110" height="2" fill="#cc1e2c" opacity="0.85"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,11 +4,15 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>BLACK-HIVE | Tactical Swarm Systems</title>
+    <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <main role="main">
       <section class="hero" aria-labelledby="hero-title">
+        <a class="hero__brand" href="index.html" aria-label="BLACK-HIVE">
+          <img src="assets/logo.svg" alt="BLACK-HIVE" />
+        </a>
         <div class="hero__bg" aria-hidden="true"></div>
         <div
           class="hero__card"

--- a/style.css
+++ b/style.css
@@ -25,6 +25,34 @@ main {
   min-height: 100vh;
 }
 
+.hero__brand {
+  position: absolute;
+  top: max(12px, env(safe-area-inset-top, 0px) + 12px);
+  left: max(12px, env(safe-area-inset-left, 0px) + 12px);
+  display: inline-block;
+  z-index: 5;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(4px) saturate(1.1);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.hero__brand img {
+  height: 28px;
+  display: block;
+}
+
+@media (min-width: 900px) {
+  .hero__brand img {
+    height: 34px;
+  }
+}
+
+.hero__brand:hover {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
 .hero__bg {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- add BLACK-HIVE SVG logo and favicon assets for branding
- surface the hero overlay link with the new logo and register the favicon in the head
- style the floating brand badge so it stays pinned above the hero artwork across breakpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdad207da883259bb88446a1e93055