### PR TITLE
Adjust hero banner styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -128,7 +128,7 @@ main {
   color: #1f1f1f;
 }
 
-.actions {
+.hero__card .actions {
   display: flex;
   gap: 12px;
   justify-content: center;
@@ -193,7 +193,7 @@ main {
     font-size: 28px;
   }
 
-  .actions {
+  .hero__card .actions {
     flex-direction: column;
   }
 
@@ -213,7 +213,7 @@ main {
   position: relative;
   max-width: 1100px;
   margin: clamp(12px, 4vw, 24px) auto;
-  border: 1px solid var(--line);
+  border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 20px;
   overflow: hidden;
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.35);
@@ -277,12 +277,12 @@ main {
   left: 0;
   right: 0;
   bottom: 0;
-  background: #fff;
+  background: #f7f8fa;
   color: #0b0d0e;
-  padding: 14px 18px;
-  border-top-left-radius: 18px;
-  border-top-right-radius: 18px;
-  box-shadow: 0 -2px 0 rgba(0, 0, 0, 0.05), 0 18px 40px rgba(0, 0, 0, 0.35);
+  padding: 16px 18px;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 0;
+  box-shadow: none;
   z-index: 2;
 }
 
@@ -296,7 +296,7 @@ main {
 
 .banner__title {
   margin: 0;
-  font: 700 18px / 1.2 Inter, system-ui, sans-serif;
+  font: 800 20px / 1.25 Inter, system-ui, sans-serif;
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- update the hero frame border to the requested light treatment
- restyle the hero banner to sit flush inside the frame with a light grey background
- preserve the brand chip styling while aligning the CTA text styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdbe5a243483259babc5b6a1510bda