### PR TITLE
Tidy hero layout and nav dropdown behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,21 +53,45 @@
         const btn = document.querySelector('.nav__toggle');
         const panel = document.getElementById('navPanel');
         if(!btn || !panel) return;
-        function setOpen(open){
-          btn.setAttribute('aria-expanded', String(open));
-          if(open){ panel.hidden = false; requestAnimationFrame(()=>panel.setAttribute('data-open','true')); }
-          else{
-            panel.removeAttribute('data-open');
-            panel.addEventListener('transitionend',()=>{ panel.hidden = true; }, {once:true});
-          }
+
+        function placePanel(){
+          const r = btn.getBoundingClientRect();
+          // fixed so it’s not clipped by hero overflow
+          panel.style.position = 'fixed';
+          panel.style.top = (r.bottom + 8) + 'px';
+          // align the panel’s right edge with the button’s right edge
+          panel.style.left = 'auto';
+          panel.style.right = Math.max(12, window.innerWidth - (r.right)) + 'px';
+          panel.style.zIndex = '9999';
         }
+
+        function openPanel(){
+          panel.hidden = false;
+          placePanel();
+          // let CSS handle fade-in
+          requestAnimationFrame(()=> panel.setAttribute('data-open','true'));
+          btn.setAttribute('aria-expanded','true');
+        }
+        function closePanel(){
+          panel.removeAttribute('data-open');
+          panel.addEventListener('transitionend', ()=>{
+            panel.hidden = true;
+            panel.removeAttribute('style');
+          }, {once:true});
+          btn.setAttribute('aria-expanded','false');
+        }
+
         let open = false;
-        btn.addEventListener('click', ()=>{ open=!open; setOpen(open); });
+        btn.addEventListener('click', ()=>{
+          open ? closePanel() : openPanel();
+          open = !open;
+        });
+        window.addEventListener('resize', ()=>{ if(open){ placePanel(); } });
         document.addEventListener('click', (e)=>{
           if(!open) return;
-          if(!panel.contains(e.target) && e.target !== btn){ open=false; setOpen(false); }
+          if(!panel.contains(e.target) && e.target !== btn){ open = false; closePanel(); }
         });
-        document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && open){ open=false; setOpen(false); }});
+        document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && open){ open=false; closePanel(); }});
       })();
     </script>
   </body>

--- a/style.css
+++ b/style.css
@@ -217,6 +217,7 @@ main {
   border-radius: 20px;
   overflow: hidden;
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.35);
+  min-height: min(80vh, 900px);
 }
 
 .hero--framed .hero__bg {
@@ -224,6 +225,7 @@ main {
   inset: 0;
   background-size: cover;
   background-position: center;
+  will-change: transform;
 }
 
 .hero--framed::before {
@@ -279,7 +281,7 @@ main {
   bottom: 0;
   background: #f7f8fa;
   color: #0b0d0e;
-  padding: 16px 18px;
+  padding: clamp(16px, 2.8vw, 22px) clamp(18px, 3vw, 28px);
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 0;
   box-shadow: none;
@@ -290,20 +292,19 @@ main {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 14px;
+  gap: 16px;
   flex-wrap: wrap;
 }
 
 .banner__title {
   margin: 0;
-  font: 800 20px / 1.25 Inter, system-ui, sans-serif;
+  font: 800 clamp(18px, 2.6vw, 24px) / 1.25 Inter, system-ui, sans-serif;
 }
 
 .banner__desc {
   margin: 6px 0 0;
-  font: 400 14px / 1.4 Inter, system-ui, sans-serif;
+  font: 400 14px / 1.45 Inter, system-ui, sans-serif;
   color: #333;
-  flex-basis: 100%;
 }
 
 .actions {
@@ -342,7 +343,7 @@ main {
   transform: translateY(-1px);
 }
 
-@media (max-width: 520px) {
+@media (max-width: 560px) {
   .banner__row {
     flex-direction: column;
     align-items: stretch;
@@ -375,7 +376,7 @@ main {
   appearance:none; cursor:pointer;
   background:rgba(0,0,0,.28);
   color:var(--ink); border:1px solid rgba(255,255,255,.12);
-  padding:8px 12px; border-radius:12px;
+  padding:10px 14px; border-radius:12px;
   font:700 12px/1 Inter, system-ui, sans-serif; letter-spacing:.08em;
   backdrop-filter: blur(6px) saturate(1.1);
   transition:transform .15s ease, box-shadow .15s ease;
@@ -389,14 +390,15 @@ main {
   border-radius:14px; padding:10px;
   box-shadow: 0 20px 50px rgba(0,0,0,.35);
   backdrop-filter: blur(8px) saturate(1.1);
-  /* animation container */
+  -webkit-backdrop-filter: blur(8px) saturate(1.1);
   opacity:0; transform: translateY(-6px) scale(.98);
   transition: opacity .18s ease, transform .18s ease;
+  z-index: 50;
 }
 .nav__panel[data-open="true"]{ opacity:1; transform: translateY(0) scale(1); }
 .nav__list{ list-style:none; margin:0; padding:6px 0; }
 .nav__link{
-  display:block; padding:10px 12px; border-radius:10px;
+  display:block; padding:12px 12px; border-radius:10px;
   color:var(--ink); text-decoration:none; font:600 14px/1 Inter, system-ui, sans-serif;
   transition: background-color .15s ease, transform .15s ease;
 }
@@ -407,10 +409,15 @@ main {
 
 /* Mobile: make panel full-width chip under button */
 @media (max-width:520px){
-  .nav__panel{ min-width: calc(100vw - 24px); left:12px; right:12px }
+  .nav__panel[data-open="true"]{
+    min-width: calc(100vw - 24px);
+  }
 }
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce){
-  .nav__toggle, .nav__panel, .nav__link{ transition:none !important }
+  *{
+    animation: none !important;
+    transition: none !important;
+  }
 }


### PR DESCRIPTION
## Summary
- extend the framed hero to maintain a tall, responsive photo canvas and enable smoother background rendering
- refresh the bottom banner spacing, typography, and buttons to create a roomier boxed CTA inside the frame
- restyle and reposition the nav dropdown with a fixed-position toggle script to prevent clipping and improve mobile behavior

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cdc7ac50708325bf97c95e397fbab0