### PR TITLE
Increase hero height for consistent scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,17 @@
+:root{
+  /* hero height target: longer than viewport to force scroll */
+  --hero-min: 120svh;          /* fallback for Safari/iOS */
+}
+
+/* Prefer dynamic viewport on supported browsers */
+@supports (height: 100dvh){
+  :root{ --hero-min: 120dvh; }
+}
+
+@media (max-width: 560px){
+  :root{ --hero-min: 110svh; }
+}
+
 :root {
   color-scheme: light;
   font-family: "Helvetica Neue", Arial, sans-serif;
@@ -217,7 +231,7 @@ main {
   border-radius: 20px;
   overflow: hidden;
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.35);
-  min-height: min(80vh, 900px);
+  min-height: var(--hero-min);
 }
 
 .hero--framed .hero__bg {
@@ -225,6 +239,7 @@ main {
   inset: 0;
   background-size: cover;
   background-position: center;
+  background-repeat: no-repeat;
   will-change: transform;
 }
 
@@ -281,18 +296,19 @@ main {
   bottom: 0;
   background: #f7f8fa;
   color: #0b0d0e;
-  padding: clamp(16px, 2.8vw, 22px) clamp(18px, 3vw, 28px);
+  padding: clamp(20px, 3.2vw, 28px) clamp(22px, 3.6vw, 32px);
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 0;
   box-shadow: none;
   z-index: 2;
+  min-height: 96px;
 }
 
 .banner__row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 18px;
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## Summary
- define a dynamic `--hero-min` viewport variable to keep the framed hero taller than the screen and encourage scrolling across browsers
- update the framed hero background and banner spacing so the extended hero still fills cleanly and the call-to-action band matches the new height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdc9effa348325acc5f61cbd685ccb