### PR TITLE
Force tall hero with robust --vh fallback; stretch bg/img; larger banner; ensure page scrolls on all devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,5 +94,16 @@
         document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && open){ open=false; closePanel(); }});
       })();
     </script>
+    <script>
+      (function(){
+        function setVH(){
+          const h = window.innerHeight * 0.01;
+          document.documentElement.style.setProperty('--vh', h + 'px');
+        }
+        setVH();
+        window.addEventListener('resize', setVH);
+        window.addEventListener('orientationchange', setVH);
+      })();
+    </script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,15 +1,11 @@
-:root{
-  /* hero height target: longer than viewport to force scroll */
-  --hero-min: 120svh;          /* fallback for Safari/iOS */
+/* Robust viewport height variables */
+:root {
+  --vh: 1vh;               /* JS will update this to real innerHeight/100 */
+  --hero-min-mult: 120;    /* tweakable: 120 = 120vh */
 }
-
-/* Prefer dynamic viewport on supported browsers */
-@supports (height: 100dvh){
-  :root{ --hero-min: 120dvh; }
-}
-
-@media (max-width: 560px){
-  :root{ --hero-min: 110svh; }
+/* Prefer dynamic viewport on supporting browsers */
+@supports (height: 100dvh) {
+  :root { --vh: 1dvh; }
 }
 
 :root {
@@ -21,6 +17,11 @@
   box-sizing: border-box;
 }
 
+html, body {
+  height: auto !important;
+  overflow: auto !important;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -28,6 +29,7 @@ body {
   flex-direction: column;
   background-color: #ffffff;
   color: #0f0f0f;
+  overscroll-behavior-y: none;
 }
 
 main {
@@ -231,16 +233,29 @@ main {
   border-radius: 20px;
   overflow: hidden;
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.35);
-  min-height: var(--hero-min);
+}
+
+section.hero.hero--framed {
+  /* force a tall section; use !important to beat earlier rules */
+  min-height: calc(var(--vh) * var(--hero-min-mult)) !important;
+  display: block;
 }
 
 .hero--framed .hero__bg {
   position: absolute;
   inset: 0;
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
+  background-size: cover !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
   will-change: transform;
+}
+
+.hero__bg img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
 }
 
 .hero--framed::before {
@@ -296,12 +311,12 @@ main {
   bottom: 0;
   background: #f7f8fa;
   color: #0b0d0e;
-  padding: clamp(20px, 3.2vw, 28px) clamp(22px, 3.6vw, 32px);
+  padding: clamp(22px, 3.6vw, 32px) clamp(24px, 4vw, 36px) !important;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 0;
   box-shadow: none;
   z-index: 2;
-  min-height: 96px;
+  min-height: 110px;
 }
 
 .banner__row {


### PR DESCRIPTION
## Summary
- add robust viewport height CSS variables and ensure the hero section respects them with a taller minimum height
- update hero background and banner styles to keep imagery covering the frame and expand the call-to-action padding
- inject a small script to keep the CSS `--vh` value in sync with the actual viewport height for precise sizing

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cdcbae67a4832581f2046713296ce3