### PR TITLE
Hero image focal fix: shift background/object-position to show more of the drone (mobile & desktop)

### DIFF
--- a/style.css
+++ b/style.css
@@ -241,21 +241,40 @@ section.hero.hero--framed {
   display: block;
 }
 
+@media (max-width: 420px) {
+  section.hero.hero--framed,
+  .hero--framed {
+    min-height: 105svh !important;
+  }
+}
+
 .hero--framed .hero__bg {
   position: absolute;
   inset: 0;
   background-size: cover !important;
-  background-position: center !important;
-  background-repeat: no-repeat !important;
+  background-position: center 42% !important;
+  background-repeat: no-repeat;
   will-change: transform;
+}
+
+@media (max-width: 600px) {
+  .hero--framed .hero__bg {
+    background-position: center 35% !important;
+  }
 }
 
 .hero__bg img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  object-position: center;
+  object-position: center 42%;
   display: block;
+}
+
+@media (max-width: 600px) {
+  .hero__bg img {
+    object-position: center 35%;
+  }
 }
 
 .hero--framed::before {


### PR DESCRIPTION
## Summary
- adjust the framed hero background focus so more of the drone stays in frame on desktop and tablets
- mirror the same focal shift for any inline hero image and add mobile-specific positioning tweaks
- lengthen the compact-phone min-height override to reduce cropping on very small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdde04cac08325ae30b919cd093412