### PR TITLE
Nav refresh: Overview/Founder/SWARM PANEL (crimson highlight)/Research/Contact + add new subpages with framed hero

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -29,16 +29,17 @@
             </ul>
           </div>
         </nav>
-        <div class="hero__banner" role="region" aria-label="Primary Call to Action">
-          <div class="banner__row">
-            <p class="banner__title">BLACK-HIVE: Tactical Swarm Systems</p>
-            <p class="banner__desc">Exploring next-generation swarm coordination for security, events, and critical response.</p>
-            <div class="actions">
-              <a href="assets/BLACK-HIVE_OnePager_2025.pdf" class="btn btn--primary" target="_blank" rel="noopener">Download One-Pager</a>
-              <a href="mailto:contact@blackhive.ai" class="btn btn--outline">Contact Us</a>
-            </div>
-          </div>
-        </div>
+        <div class="hero__subbadge"><p class="title">Contact</p></div>
+      </section>
+    </main>
+    <main class="content">
+      <section>
+        <h1>Contact</h1>
+        <p>For grant applications, partnerships, or accelerator interest:</p>
+        <ul>
+          <li>Email: <a href="mailto:contact@blackhive.ai">contact@blackhive.ai</a></li>
+          <li>Subject suggestion: “BLACK-HIVE — Partnership/Grant”</li>
+        </ul>
       </section>
     </main>
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>

--- a/founder.html
+++ b/founder.html
@@ -29,16 +29,14 @@
             </ul>
           </div>
         </nav>
-        <div class="hero__banner" role="region" aria-label="Primary Call to Action">
-          <div class="banner__row">
-            <p class="banner__title">BLACK-HIVE: Tactical Swarm Systems</p>
-            <p class="banner__desc">Exploring next-generation swarm coordination for security, events, and critical response.</p>
-            <div class="actions">
-              <a href="assets/BLACK-HIVE_OnePager_2025.pdf" class="btn btn--primary" target="_blank" rel="noopener">Download One-Pager</a>
-              <a href="mailto:contact@blackhive.ai" class="btn btn--outline">Contact Us</a>
-            </div>
-          </div>
-        </div>
+        <div class="hero__subbadge"><p class="title">Founder</p></div>
+      </section>
+    </main>
+    <main class="content">
+      <section>
+        <h1>Founder</h1>
+        <p>Founder profile, background, and motivation. Include relevant experience, domain knowledge, and partnerships as they materialize.</p>
+        <p>Email: <a href="mailto:contact@blackhive.ai">contact@blackhive.ai</a></p>
       </section>
     </main>
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>

--- a/overview.html
+++ b/overview.html
@@ -29,16 +29,18 @@
             </ul>
           </div>
         </nav>
-        <div class="hero__banner" role="region" aria-label="Primary Call to Action">
-          <div class="banner__row">
-            <p class="banner__title">BLACK-HIVE: Tactical Swarm Systems</p>
-            <p class="banner__desc">Exploring next-generation swarm coordination for security, events, and critical response.</p>
-            <div class="actions">
-              <a href="assets/BLACK-HIVE_OnePager_2025.pdf" class="btn btn--primary" target="_blank" rel="noopener">Download One-Pager</a>
-              <a href="mailto:contact@blackhive.ai" class="btn btn--outline">Contact Us</a>
-            </div>
-          </div>
-        </div>
+        <div class="hero__subbadge"><p class="title">Overview</p></div>
+      </section>
+    </main>
+    <main class="content">
+      <section>
+        <h1>Overview</h1>
+        <p>BLACK-HIVE explores tactical swarm systems for security, large-venue monitoring, and critical response. This page summarizes the mission, scope, and near-term milestones.</p>
+        <ul>
+          <li>Problem: blind spots and slow response in dynamic environments</li>
+          <li>Approach: coordinated multi-UAS autonomy with human-on-the-loop control</li>
+          <li>Outcomes: improved coverage, faster detection, safer escalation</li>
+        </ul>
       </section>
     </main>
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>

--- a/research.html
+++ b/research.html
@@ -29,16 +29,14 @@
             </ul>
           </div>
         </nav>
-        <div class="hero__banner" role="region" aria-label="Primary Call to Action">
-          <div class="banner__row">
-            <p class="banner__title">BLACK-HIVE: Tactical Swarm Systems</p>
-            <p class="banner__desc">Exploring next-generation swarm coordination for security, events, and critical response.</p>
-            <div class="actions">
-              <a href="assets/BLACK-HIVE_OnePager_2025.pdf" class="btn btn--primary" target="_blank" rel="noopener">Download One-Pager</a>
-              <a href="mailto:contact@blackhive.ai" class="btn btn--outline">Contact Us</a>
-            </div>
-          </div>
-        </div>
+        <div class="hero__subbadge"><p class="title">Research</p></div>
+      </section>
+    </main>
+    <main class="content">
+      <section>
+        <h1>Research</h1>
+        <p>Notes on autonomy, multi-agent coordination, simulation, and perception. Link public write-ups, experiments, and datasets as they become available.</p>
+        <p><a href="assets/BLACK-HIVE_OnePager_2025.pdf" target="_blank" rel="noopener">Download the one-pager</a></p>
       </section>
     </main>
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>

--- a/style.css
+++ b/style.css
@@ -453,8 +453,11 @@ section.hero.hero--framed {
   transition: background-color .15s ease, transform .15s ease;
 }
 .nav__link:hover{ background:rgba(255,255,255,.06); transform:translateX(2px); }
-.nav__link--highlight{ color:#111; background:var(--amber); }
-.nav__link--highlight:hover{ filter:brightness(.96) }
+.nav__link--highlight{
+  background: #cc1e2c;
+  color: #fff;
+}
+.nav__link--highlight:hover{ filter: brightness(.95); }
 .nav__divider{ height:1px; margin:6px 10px; background:rgba(255,255,255,.12); border-radius:1px }
 
 /* Mobile: make panel full-width chip under button */
@@ -471,3 +474,17 @@ section.hero.hero--framed {
     transition: none !important;
   }
 }
+
+/* Slim hero badge used on subpages */
+.hero__subbadge{
+  position:absolute; left:0; right:0; bottom:0;
+  background:#f7f8fa; color:#0b0d0e;
+  padding:14px 18px; border-top:1px solid rgba(0,0,0,.10); border-radius:0;
+}
+.hero__subbadge .title{ margin:0; font:800 18px/1.2 Inter, system-ui, sans-serif }
+
+/* Generic content block */
+.content{ max-width:1100px; margin:28px auto; padding:0 16px; }
+.content h1{ font:800 28px/1.2 Inter, system-ui, sans-serif; margin:0 0 10px }
+.content p, .content li{ font:400 16px/1.6 Inter, system-ui, sans-serif; color:#d9e1ea }
+.content a{ color:#e8edf2; text-decoration:underline; text-underline-offset:2px }


### PR DESCRIPTION
## Summary
- update the hero dropdown navigation to the new Overview, Founder, SWARM PANEL, Research, and Contact destinations
- apply the crimson highlight treatment to the featured SWARM PANEL link
- add overview, founder, research, and contact subpages that reuse the framed hero and include placeholder copy

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cde1ace61483259a85d1934f912f75