### PR TITLE
Unify MENU + logo tab styling and change Join Waitlist CTA to brand red

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
           <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
         </a>
         <nav class="hero__nav" aria-label="Site">
-          <button class="nav__toggle" aria-expanded="false" aria-controls="navPanel">
+          <button class="nav__menu-btn" aria-expanded="false" aria-controls="navPanel">
             MENU ▾
           </button>
           <div class="nav__panel" id="navPanel" hidden>
@@ -47,7 +47,7 @@
     </script>
     <script>
       (function(){
-        const btn = document.querySelector('.nav__toggle');
+        const btn = document.querySelector('.nav__menu-btn');
         const panel = document.getElementById('navPanel');
         if(!btn || !panel) return;
 

--- a/style.css
+++ b/style.css
@@ -55,34 +55,30 @@ main {
 }
 
 .brand {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 10px;
-  color: #e8edf2;
-  text-decoration: none;
+  gap: 8px;
+  padding: 0 16px;
+  height: 44px;
+  border-radius: 8px;
+  background: #d1d3d4;
 }
 
 .brand img {
-  height: 32px;
-  display: block;
+  height: 22px;
 }
 
-@media (min-width: 900px) {
-  .brand img {
-    height: 36px;
-  }
-}
-
-.brand:hover img {
-  filter: drop-shadow(0 0 6px rgba(240,180,41,.25));
+.brand span {
+  font: 700 14px / 1 Inter, system-ui, sans-serif;
+  letter-spacing: 1px;
+  color: #111;
 }
 
 .brand__text {
-  font-family: "Inter", system-ui, sans-serif;
-  font-weight: 800;
-  letter-spacing: 1.5px;
+  font: 700 14px / 1 Inter, system-ui, sans-serif;
+  letter-spacing: 1px;
   text-transform: uppercase;
-  color: #e8edf2;
+  color: #111;
 }
 
 .hero__brand:hover {
@@ -374,11 +370,15 @@ section.hero.hero--framed {
 }
 
 .btn--primary {
-  background: var(--amber);
-  color: #111;
+  background: #cc1e2c;
+  border: 1px solid #cc1e2c;
+  color: #fff;
+  font-weight: 700;
 }
 
 .btn--primary:hover {
+  background: #b31a26;
+  border-color: #b31a26;
   transform: translateY(-1px);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
 }
@@ -422,16 +422,28 @@ section.hero.hero--framed {
   top: max(12px, env(safe-area-inset-top,0) + 12px);
   right:max(12px, env(safe-area-inset-right,0) + 12px);
 }
-.nav__toggle{
-  appearance:none; cursor:pointer;
-  background:rgba(0,0,0,.28);
-  color:var(--ink); border:1px solid rgba(255,255,255,.12);
-  padding:10px 14px; border-radius:12px;
-  font:700 12px/1 Inter, system-ui, sans-serif; letter-spacing:.08em;
-  backdrop-filter: blur(6px) saturate(1.1);
-  transition:transform .15s ease, box-shadow .15s ease;
+.nav__menu-btn,
+.nav__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+  height: 44px;
+  border-radius: 8px;
+  background: #d1d3d4;
+  font: 700 14px / 1 Inter, system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: #111;
+  cursor: pointer;
+  transition: background 0.2s;
+  border: none;
 }
-.nav__toggle:hover{ transform:translateY(-1px); box-shadow:0 8px 20px rgba(0,0,0,.25) }
+
+.nav__menu-btn:hover,
+.nav__toggle:hover {
+  background: #c5c7c9;
+}
 
 .nav__panel{
   position:absolute; right:0; margin-top:8px; min-width:220px;


### PR DESCRIPTION
## Summary
- restyle the navigation menu button to match the badge treatment and reference the new `nav__menu-btn` class in the hero markup and script
- refresh the shared badge styles so the BLACK-HIVE logo tab uses the updated grey pill treatment
- swap the primary call-to-action button to the brand red palette for normal and hover states

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68cde75f805483259a510add71b0961f