### PR TITLE
Add SWARM PANEL page and nav link; scope landing background to home only

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a href="panel.html" class="nav__link nav__link--highlight">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/founder.html
+++ b/founder.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a href="panel.html" class="nav__link nav__link--highlight">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css" />
   </head>
-  <body>
+  <body class="home">
     <main role="main">
       <section class="hero hero--framed">
         <div class="hero__bg" aria-hidden="true"></div>
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a href="panel.html" class="nav__link nav__link--highlight">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/overview.html
+++ b/overview.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a href="panel.html" class="nav__link nav__link--highlight">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/panel.html
+++ b/panel.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a href="panel.html" class="nav__link nav__link--highlight">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/research.html
+++ b/research.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a href="panel.html" class="nav__link nav__link--highlight">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/style.css
+++ b/style.css
@@ -88,8 +88,11 @@ main {
 .hero__bg {
   position: absolute;
   inset: 0;
-  background: url("drone-stadium.jpg") center / cover no-repeat;
   z-index: 0;
+}
+
+.home .hero__bg {
+  background: url("drone-stadium.jpg") center / cover no-repeat;
 }
 
 .hero::after {
@@ -465,11 +468,15 @@ section.hero.hero--framed {
   transition: background-color .15s ease, transform .15s ease;
 }
 .nav__link:hover{ background:rgba(255,255,255,.06); transform:translateX(2px); }
-.nav__link--highlight{
+.nav__link--highlight,
+.nav__link--cta{
   background: #cc1e2c;
   color: #fff;
+  font-weight: 700;
+  box-shadow: 0 12px 30px rgba(204, 30, 44, 0.35);
 }
-.nav__link--highlight:hover{ filter: brightness(.95); }
+.nav__link--highlight:hover,
+.nav__link--cta:hover{ filter: brightness(.95); }
 .nav__divider{ height:1px; margin:6px 10px; background:rgba(255,255,255,.12); border-radius:1px }
 
 /* Mobile: make panel full-width chip under button */

--- a/swarm/index.html
+++ b/swarm/index.html
@@ -1,0 +1,527 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>SWARM PANEL</title>
+<style>
+  :root{
+    /* Brand */
+    --red:#cc1e2c; --ink:#e8f1fb; --muted:#a7b4c4;
+
+    /* UI */
+    --bg:#0b0f14; --panel:#101821; --line:#1b2633;
+
+    /* Status */
+    --ok:#74dba0; --bad:#ff6b6b;
+
+    /* Surfaces */
+    --chip:#0f151c; --chip2:#0c1116;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--ink);font:13.5px/1.5 Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif}
+
+  /* ===== App chrome ===== */
+  .wrap{display:grid;grid-template-columns:2fr 1.25fr;gap:16px;max-width:1200px;margin:18px auto;padding:0 12px}
+  @media (max-width:1000px){.wrap{grid-template-columns:1fr}}
+  .card{
+    background: rgba(16,24,33,.72);
+    backdrop-filter: blur(8px) saturate(120%);
+    border:1px solid rgba(255,255,255,.06);
+    border-radius:14px; box-shadow:0 18px 50px rgba(0,0,0,.45)
+  }
+  .card>.hd{padding:12px;border-bottom:1px solid rgba(255,255,255,.06);display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+  .card>.bd{padding:12px}
+
+  h1,h2{margin:0;letter-spacing:1.6px;font-weight:900;text-transform:uppercase}
+  h1{font-size:15px;color:#e9eef6;text-shadow:0 1px 0 rgba(0,0,0,.8)}
+  h1 b{color:var(--red)}
+  h2{font-size:15px;color:#e9eef6}
+  h2 b{color:var(--red)}
+  .sub{color:var(--muted);font-size:12px;margin:0}
+
+  .controls{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+  .btn{background:rgba(255,255,255,.05);color:var(--ink);border:1px solid rgba(255,255,255,.08);height:36px;padding:7px 12px;border-radius:12px;font:600 14px/1 Inter;cursor:pointer;box-shadow:0 6px 18px rgba(0,0,0,.25);transition:transform .15s,filter .15s,background .15s}
+  .btn:hover{filter:brightness(1.06)}
+  .btn--primary{background:linear-gradient(180deg,#e03a46,#b7232f);border-color:#92202a;box-shadow:0 10px 30px rgba(204,30,44,.35), inset 0 1px 0 rgba(255,255,255,.12)}
+  .select, .input{background:rgba(255,255,255,.05);color:var(--ink);border:1px solid rgba(255,255,255,.08);height:36px;padding:7px 10px;border-radius:10px;font:inherit}
+  .status{padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.05);font-weight:800;font-size:12px}
+  .status.ok{color:var(--ok)} .status.neutral{color:var(--muted)}
+
+  /* Map */
+  .map-wrap{position:relative}
+  #mapCanvas{width:100%;aspect-ratio:16/10;display:block;border-radius:12px;background:#0c1218}
+  .legend{
+    position:absolute;left:10px;top:10px;display:flex;gap:8px;z-index:5;
+    background:rgba(12,18,24,.6);border:1px solid rgba(255,255,255,.06);padding:6px 8px;border-radius:12px;
+    box-shadow:0 8px 24px rgba(0,0,0,.35);backdrop-filter: blur(4px);font-size:12px;color:var(--muted);pointer-events:none
+  }
+  .dot{width:8px;height:8px;border-radius:50%;display:inline-block;margin-right:4px}
+  .c-patrol{background:var(--red)} .c-rtb{background:var(--bad)} .c-assist{background:#f05c7a} .c-dist{background:#c0cad5}
+
+  /* HUD */
+  .hud{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}
+  .kv{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.06);border-radius:12px;padding:6px 8px;display:flex;gap:6px;align-items:center;box-shadow:inset 0 0 0 1px rgba(255,255,255,.03)}
+  .kv .k{color:var(--muted);font-size:12px} .kv .v{font-weight:800}
+
+  /* Fleet & Alerts */
+  .grid{display:grid;grid-template-columns:1fr;gap:10px;max-height:360px;overflow:auto}
+  .row{display:grid;grid-template-columns:68px 1fr 85px 76px 56px;gap:8px;align-items:center;padding:8px;border-radius:12px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.06);font-size:13px;transition:background .15s,outline .15s}
+  .row .id{font-weight:800;letter-spacing:.3px}
+  .row .mode{color:var(--muted)}
+  .row:hover{outline:1px dashed rgba(255,255,255,.25);outline-offset:2px}
+  .bat{height:7px;background:#0a1216;border:1px solid rgba(255,255,255,.06);border-radius:12px;position:relative;overflow:hidden}
+  .bat>.f{position:absolute;inset:0 100% 0 0;background:linear-gradient(90deg,#4ad7a4,#9ff2dd);border-radius:12px}
+
+  .feed{display:flex;flex-direction:column;gap:10px;max-height:360px;overflow:auto}
+  .alert{background:rgba(255,255,255,.05);border:1px solid rgba(255,255,255,.08);border-left:4px solid var(--red);padding:8px 10px;border-radius:12px;box-shadow:0 10px 28px rgba(0,0,0,.35)}
+  .ts{color:var(--muted);font-size:11px}
+
+  button,.row,.kv{transition:filter .15s,background-color .15s,transform .15s}
+  :focus-visible{outline:2px solid rgba(255,255,255,.25);outline-offset:2px;border-radius:6px}
+  @media (prefers-reduced-motion: reduce){*{animation:none!important;transition:none!important}}
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <!-- LEFT -->
+    <div class="card">
+      <div class="hd">
+        <div class="controls" style="gap:12px">
+          <h1>SWARM <b>PANEL</b></h1>
+          <select id="scenarioSelect" class="select" aria-label="Scenario">
+            <option value="perimeter" selected>Scenario: Perimeter Sweep</option>
+            <option value="incident">Scenario: Crowd Incident (assist)</option>
+          </select>
+        </div>
+        <div class="controls">
+          <input id="cmdInput" class="input" placeholder="Type a command… (/ to focus)" style="width:240px"/>
+          <button id="cmdSend" class="btn">Send</button>
+          <span id="statusPill" class="status neutral">Grounded</span>
+        </div>
+      </div>
+      <div class="bd">
+        <div class="controls" style="margin-bottom:10px">
+          <button id="launchButton" class="btn btn--primary" aria-label="Launch Fleet">Launch Fleet (L)</button>
+          <button id="rtbButton" class="btn" aria-label="Return to Base">Return to Base (R)</button>
+        </div>
+
+        <div class="map-wrap">
+          <div class="legend" aria-hidden="true">
+            <span><span class="dot c-patrol"></span>PATROL</span>
+            <span><span class="dot c-rtb"></span>RTB</span>
+            <span><span class="dot c-assist"></span>ASSIST</span>
+            <span><span class="dot c-dist"></span>DISTRESS</span>
+          </div>
+          <canvas id="mapCanvas" role="img" aria-label="Swarm area map showing drones and alerts"></canvas>
+        </div>
+
+        <div class="hud">
+          <div class="kv"><span class="k">Operator</span><span class="v">1</span></div>
+          <div class="kv"><span class="k">Fleet</span><span class="v" id="fleetValue">10</span></div>
+          <div class="kv"><span class="k">Active</span><span class="v" id="activeValue">0</span></div>
+          <div class="kv"><span class="k">Time</span><span class="v" id="timeValue">0.0s</span></div>
+          <div class="kv"><span class="k">Incidents</span><span class="v" id="incidentsValue">0</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT -->
+    <div class="card">
+      <div class="hd">
+        <div>
+          <h2><b>Fleet</b> & Alerts</h2>
+          <p class="sub">Live status • Modes: GROUND / PATROL / ASSIST / DISTRESS / RTB / CHARGE</p>
+        </div>
+        <div class="controls"><button id="exportBtn" class="btn" aria-label="Export Alerts">Export Alerts</button></div>
+      </div>
+      <div class="bd">
+        <div class="grid" id="fleetList"></div>
+        <h2 style="margin:14px 0 8px"><b>Alerts</b></h2>
+        <div class="feed" id="feedContainer" role="log" aria-live="polite"></div>
+      </div>
+    </div>
+  </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  /* ===== Helpers ===== */
+  const clamp=(v,a,b)=>Math.max(a,Math.min(b,v));
+  const lerpDt=(perSec,dt)=>1 - Math.pow(1-perSec,dt);
+  let _actx; function ping(kind='assist'){ try{
+    _actx=_actx||new (window.AudioContext||window.webkitAudioContext)();
+    const ctx=_actx,o=ctx.createOscillator(),g=ctx.createGain();
+    const cfg=(kind==='distress')?{f1:720,f2:540,d:.22}:(kind==='resolve')?{f1:520,f2:880,d:.18}:{f1:600,f2:680,d:.18};
+    o.type='sine'; o.frequency.setValueAtTime(cfg.f1,ctx.currentTime);
+    o.frequency.linearRampToValueAtTime(cfg.f2,ctx.currentTime+cfg.d*.7);
+    g.gain.setValueAtTime(.0001,ctx.currentTime); g.gain.exponentialRampToValueAtTime(.08,ctx.currentTime+.02);
+    g.gain.exponentialRampToValueAtTime(.0001,ctx.currentTime+cfg.d);
+    o.connect(g); g.connect(ctx.destination); o.start(); o.stop(ctx.currentTime+cfg.d);
+  }catch(e){} }
+
+  /* ===== Config ===== */
+  const CFG={
+    COUNT:10,
+    WORLD:{x0:-90,y0:-60,x1:90,y1:60},
+    BASE:{x:-70,y:-45},
+    RINGS:[30,40,50,60,70],
+    SIM:{ speed:.85, drain:.02, recharge:.4, low:20, rtbLerp:.18, altRate:.5 },
+    COL:{ drone:'#cc1e2c', bad:'#ff6b6b', map:'#0c1218', line:'#1b2633', pitch:'#0a1519', pitchLine:'#20313b', ring:'#17202a', base:'#13212d', baseLine:'#274057' }
+  };
+
+  /* ===== DOM ===== */
+  const $=id=>document.getElementById(id);
+  const el={
+    map:$('mapCanvas'), fleetV:$('fleetValue'), activeV:$('activeValue'), timeV:$('timeValue'), incV:$('incidentsValue'),
+    list:$('fleetList'), feed:$('feedContainer'), status:$('statusPill'),
+    launch:$('launchButton'), rtb:$('rtbButton'), scenario:$('scenarioSelect'),
+    cmdIn:$('cmdInput'), cmdSend:$('cmdSend'), exportBtn:$('exportBtn')
+  };
+  const ctx=el.map.getContext('2d');
+
+  /* ===== State ===== */
+  const view={w:0,h:0,dpr:1};
+  const app={
+    drones:[], run:false, time:0, inc:0, last:0,
+    scenario:'perimeter',
+    pendingIncidentAt:null,        // schedule time to fire incident
+    assistResolver:null,
+    highlight:null, incidentId:null, helpers:[]
+  };
+
+  /* ===== Geometry ===== */
+  const toScreen=(x,y)=>{ const {x0,y0,x1,y1}=CFG.WORLD; const nx=(x-x0)/(x1-x0), ny=(y-y0)/(y1-y0); return [nx*view.w, (1-ny)*view.h]; };
+
+  /* ===== Canvas visuals ===== */
+  function drawBg(){
+    ctx.clearRect(0,0,view.w,view.h);
+
+    const [x0,y0]=toScreen(CFG.WORLD.x0,CFG.WORLD.y0), [x1,y1]=toScreen(CFG.WORLD.x1,CFG.WORLD.y1);
+    ctx.fillStyle=CFG.COL.map; ctx.fillRect(0,0,view.w,view.h);
+    ctx.strokeStyle=CFG.COL.line; ctx.lineWidth=2; ctx.strokeRect(x0,y1,x1-x0,y0-y1);
+
+    const [px0,py0]=toScreen(-45,-25), [px1,py1]=toScreen(45,25);
+    ctx.fillStyle=CFG.COL.pitch; ctx.strokeStyle=CFG.COL.pitchLine;
+    ctx.beginPath(); ctx.rect(px0,py1,px1-px0,py0-py1); ctx.fill(); ctx.stroke();
+
+    for(const r of CFG.RINGS){
+      ctx.strokeStyle=CFG.COL.ring; ctx.beginPath();
+      for(let a=0;a<=Math.PI*2.01;a+=0.04){
+        const [sx,sy]=toScreen(r*Math.cos(a), r*Math.sin(a));
+        a?ctx.lineTo(sx,sy):ctx.moveTo(sx,sy);
+      }
+      ctx.stroke();
+    }
+  }
+  function drawDrones(){
+    for(const d of app.drones){
+      const [sx,sy]=toScreen(d.x,d.y);
+      let color = CFG.COL.drone;
+      if(d.mode==='RTB') color = CFG.COL.bad;
+      if(d.mode==='ASSIST') color = '#f05c7a';
+      if(d.mode==='DISTRESS') color = '#c0cad5';
+
+      // glow
+      ctx.save();
+      ctx.globalAlpha = d.mode==='GROUND'?0.10:0.22;
+      ctx.shadowBlur = 16;
+      ctx.shadowColor = color;
+      ctx.fillStyle   = color;
+      ctx.beginPath(); ctx.arc(sx,sy,10,0,Math.PI*2); ctx.fill();
+      ctx.restore();
+
+      // core
+      ctx.fillStyle = color;
+      ctx.beginPath(); ctx.arc(sx,sy,5.2,0,Math.PI*2); ctx.fill();
+
+      // assist tether
+      if(d.mode==='ASSIST' && app.incidentId){
+        const trg=app.drones.find(x=>x.id===app.incidentId);
+        if(trg){
+          const [tx,ty]=toScreen(trg.x,trg.y);
+          const g = ctx.createLinearGradient(sx,sy,tx,ty);
+          g.addColorStop(0,'rgba(240,92,122,0.0)'); g.addColorStop(1,'rgba(240,92,122,0.9)');
+          ctx.strokeStyle=g; ctx.lineWidth=1.25;
+          ctx.beginPath(); ctx.moveTo(sx,sy); ctx.lineTo(tx,ty); ctx.stroke();
+        }
+      }
+
+      // spotlight
+      if(app.highlight===d.id){ ctx.strokeStyle='#fff'; ctx.lineWidth=1; ctx.beginPath(); ctx.arc(sx,sy,13,0,Math.PI*2); ctx.stroke(); }
+    }
+  }
+  function render(){ drawBg(); drawDrones(); }
+
+  /* ===== Drone creation / formation ===== */
+  function createDrone(i){
+    const th=((i*137.508)%360)*(Math.PI/180), ring=CFG.RINGS[i%CFG.RINGS.length];
+    return { id:`BH-${String(i+1).padStart(2,'0')}`, idx:i, ring, th, omega:0.35+0.05*(i%4),
+             x:CFG.BASE.x + Math.cos(th)*3, y:CFG.BASE.y + Math.sin(th)*3,
+             alt:0, altBase:12+(i%3)*3, mode:'GROUND', battery:100-i*3, link:'GOOD', blink:0 };
+  }
+
+  function startCleanSweep(){
+    // Evenly re-space angles so it always starts clean
+    const n=app.drones.length, step=(Math.PI*2)/n, base=0;
+    app.drones.forEach((d,i)=>{
+      d.mode = 'PATROL';
+      d.ring = CFG.RINGS[i%CFG.RINGS.length];
+      d.th   = base + i*step;
+      d.x    = d.ring*Math.cos(d.th);
+      d.y    = d.ring*Math.sin(d.th);
+      d.alt  = d.altBase;
+    });
+  }
+
+  function applyRingFormation(dt){
+    const baseSpin=app.time*0.12;
+    const groups=new Map();
+    app.drones.forEach(d=>{
+      if(d.mode==='PATROL'){ const k=Math.round(d.ring); (groups.get(k)||groups.set(k,[]).get(k)).push(d); }
+    });
+    groups.forEach(list=>{
+      const n=list.length; if(n<=1) return;
+      list.sort((a,b)=>a.idx-b.idx);
+      const step=(Math.PI*2)/n;
+      list.forEach((d,i)=>{
+        const target=baseSpin+i*step;
+        const diff=((target-d.th+Math.PI)%(Math.PI*2))-Math.PI;
+        d.th+=diff*Math.min(1,1.8*dt);     // gentle slotting
+        d.x=d.ring*Math.cos(d.th);
+        d.y=d.ring*Math.sin(d.th);
+      });
+    });
+  }
+
+  /* ===== Modes / update ===== */
+  function updateDrone(d,dt){
+    // battery
+    if(d.mode!=='GROUND' && d.mode!=='CHARGE'){
+      d.battery = Math.max(0, d.battery - (CFG.SIM.drain + 0.002*d.idx)*dt*60);
+    }
+
+    // auto RTB on low batt
+    if(d.mode==='PATROL' && d.battery<=CFG.SIM.low){
+      d.mode='RTB'; logAlert('ok', `RTB • ${d.id} low battery (${d.battery.toFixed(0)}%)`);
+    }
+
+    if(d.mode==='PATROL'){ d.th += d.omega*dt*CFG.SIM.speed; d.alt=d.altBase; /* x,y via formation */ }
+
+    else if(d.mode==='ASSIST'){
+      const trg = app.drones.find(x=>x.id===d.assistTargetId);
+      if(!trg){ d.mode='PATROL'; }
+      else{
+        const dx=trg.x-d.x, dy=trg.y-d.y, dist=Math.hypot(dx,dy), want=d.assistRadius||10;
+        if(dist>want*1.15){
+          const k=1 - Math.pow(1-.28, dt); d.x+=dx*k; d.y+=dy*k;
+        }else{
+          d.assistAngle=(d.assistAngle??Math.random()*Math.PI*2) + (1.0 + 0.1*(d.idx%2))*dt;
+          d.x = trg.x + want*Math.cos(d.assistAngle + (d.assistSlot||0));
+          d.y = trg.y + want*Math.sin(d.assistAngle + (d.assistSlot||0));
+        }
+        d.alt = trg.altBase;
+      }
+    }
+
+    else if(d.mode==='RTB'){
+      const k=lerpDt(CFG.SIM.rtbLerp,dt);
+      d.x += (CFG.BASE.x - d.x)*k;
+      d.y += (CFG.BASE.y - d.y)*k;
+      d.alt = Math.max(0, d.alt - CFG.SIM.altRate*dt);
+      if(Math.hypot(d.x-CFG.BASE.x,d.y-CFG.BASE.y)<2) d.mode='CHARGE';
+    }
+
+    else if(d.mode==='CHARGE'){
+      d.battery=Math.min(100, d.battery + CFG.SIM.recharge*dt);
+      d.alt=0;
+      if(d.battery>=95){ d.mode='PATROL'; d.th+=Math.PI/5; }
+    }
+
+    else if(d.mode==='DISTRESS'){
+      // slight jitter to visually read as "not nominal"
+      d.x+=Math.sin((app.time+d.idx)*2)*0.05;
+      d.y+=Math.cos((app.time+d.idx)*2)*0.05;
+    }
+
+    d.blink += dt;
+  }
+
+  /* ===== Scenarios ===== */
+  function triggerIncidentNow(){
+    const victim = app.drones[3]; // deterministic for demo
+    if(!victim) return;
+
+    victim.mode='DISTRESS';
+    app.incidentId=victim.id;
+    victim.ring=35;               // toward centre
+    victim.th += 0.15;
+
+    // choose helpers
+    const helpers = [app.drones[1], app.drones[6], app.drones[8]].slice(0,3);
+    helpers.forEach((h,j)=>{
+      h.mode='ASSIST';
+      h.assistTargetId=victim.id;
+      h.assistSlot=j*(2*Math.PI/3);
+      h.assistRadius = 10 + 2*j;
+    });
+    app.helpers = helpers;
+
+    logAlert('bad', `Incident • ${victim.id}. Assigning ${helpers.map(h=>h.id).join(', ')} to assist.`);
+    ping('distress');
+
+    // auto resolve ~14s later
+    const resolveAt = app.time + 14;
+    app.assistResolver = ()=>{ if(app.time>=resolveAt){
+      victim.mode='PATROL';
+      helpers.forEach(h=>{ if(h.mode==='ASSIST') h.mode='PATROL'; });
+      logAlert('ok','Assist complete; resuming patrol.');
+      ping('resolve');
+      app.assistResolver=null;
+    }};
+  }
+
+  function setScenario(name){
+    app.scenario = name;
+    app.incidentId=null; app.helpers.length=0; app.assistResolver=null; app.pendingIncidentAt=null;
+
+    // Reform to a clean sweep first (so both scenarios start the same)
+    startCleanSweep();
+
+    if(!app.run){
+      // Not running: just schedule if incident selected; will fire after launch
+      if(name==='incident'){ app.pendingIncidentAt = (app.time||0) + 6.0; }
+      render(); updateUI();
+      return;
+    }
+
+    if(name==='perimeter'){
+      logAlert('ok','Scenario set: Perimeter Sweep.');
+    }else{ // incident
+      app.pendingIncidentAt = app.time + 6.0; // breathing room before triggering
+      logAlert('ok','Scenario set: Crowd Incident — monitoring…');
+    }
+    render(); updateUI();
+  }
+
+  /* ===== UI ===== */
+  const batteryBar=pct=>`<div class="bat"><div class="f" style="inset:0 ${100-clamp(pct,0,100)}% 0 0"></div></div>`;
+  function updateUI(){
+    el.fleetV.textContent=app.drones.length;
+    el.activeV.textContent=app.drones.filter(d=>!['GROUND','CHARGE'].includes(d.mode)).length;
+    el.timeV.textContent=app.time.toFixed(1)+'s';
+    el.incV.textContent=app.inc;
+
+    el.list.innerHTML = app.drones.map(d=>{
+      const pct=Math.round(clamp(d.battery,0,100));
+      return `<div class="row" data-id="${d.id}">
+        <div class="id">${d.id}</div>
+        <div class="mode">${d.mode}</div>
+        ${batteryBar(pct)}
+        <div class="link">${d.link}</div>
+        <div class="alt">${Math.round(d.alt)} m</div>
+      </div>`;
+    }).join('');
+
+    [...el.list.querySelectorAll('.row')].forEach(r=>{
+      const id=r.dataset.id;
+      r.addEventListener('mouseenter',()=>{app.highlight=id; render();},{passive:true});
+      r.addEventListener('mouseleave',()=>{app.highlight=null; render();},{passive:true});
+      r.addEventListener('focus',()=>{app.highlight=id; render();});
+      r.addEventListener('blur',()=>{app.highlight=null; render();});
+    });
+  }
+
+  function logAlert(kind,msg){
+    app.inc++;
+    const box=document.createElement('div'); box.className='alert';
+    box.innerHTML=`<div class="ts">${new Date().toLocaleTimeString()}</div><div>${msg}</div>`;
+    el.feed.prepend(box);
+    while(el.feed.children.length>30) el.feed.removeChild(el.feed.lastChild);
+    if(kind==='bad') ping('distress'); else ping('assist');
+  }
+
+  /* ===== Loop ===== */
+  function tick(dt){
+    if(!app.run) return;
+    app.time += dt;
+
+    // delayed incident trigger
+    if(app.scenario==='incident' && app.pendingIncidentAt!==null && app.time >= app.pendingIncidentAt){
+      app.pendingIncidentAt=null;
+      triggerIncidentNow();
+    }
+
+    app.drones.forEach(d=>updateDrone(d,dt));
+    applyRingFormation(dt);
+    if(typeof app.assistResolver==='function') app.assistResolver();
+    updateUI(); render();
+  }
+  function loop(ts){
+    if(!app.last) app.last=ts;
+    const dt=Math.min(0.05,(ts-app.last)/1000); app.last=ts;
+    tick(dt); requestAnimationFrame(loop);
+  }
+
+  /* ===== Events ===== */
+  function bind(){
+    window.addEventListener('resize', resize, {passive:true});
+
+    el.launch.addEventListener('click', ()=>{
+      app.run=true; el.status.textContent='Live'; el.status.className='status ok';
+      startCleanSweep();
+      // If user already picked "incident", schedule the trigger
+      if(app.scenario==='incident'){ app.pendingIncidentAt = app.time + 6.0; }
+      updateUI(); render();
+    });
+
+    el.rtb.addEventListener('click', ()=>{
+      app.run=true; el.status.textContent='Live'; el.status.className='status ok';
+      app.drones.forEach(d=>{ if(d.mode!=='GROUND') d.mode='RTB'; });
+      logAlert('ok','Return to Base issued to all active units.');
+    });
+
+    el.scenario.addEventListener('change', e=>{
+      app.scenario=e.target.value;
+      setScenario(app.scenario);
+    });
+
+    el.cmdSend.addEventListener('click', ()=>{
+      const v=el.cmdIn.value.trim(); if(!v) return;
+      logAlert('ok','CMD › '+v); el.cmdIn.value='';
+    });
+    el.cmdIn.addEventListener('keydown', e=>{ if(e.key==='Enter') el.cmdSend.click(); });
+
+    window.addEventListener('keydown', e=>{
+      const k=e.key.toLowerCase();
+      if(k==='l') el.launch.click();
+      if(k==='r') el.rtb.click();
+      if(k==='/'){ e.preventDefault(); el.cmdIn.focus(); }
+    });
+
+    el.exportBtn.addEventListener('click', ()=>{
+      const logs=[...el.feed.children].map(n=>({t:n.querySelector('.ts')?.textContent||'', msg:n.lastElementChild?.textContent||''}));
+      const blob=new Blob([JSON.stringify(logs,null,2)],{type:'application/json'});
+      const a=Object.assign(document.createElement('a'),{href:URL.createObjectURL(blob),download:'blackhive-alerts.json'});
+      document.body.appendChild(a); a.click(); URL.revokeObjectURL(a.href); a.remove();
+    });
+  }
+
+  /* ===== Init ===== */
+  function resize(){
+    view.dpr=Math.min(2,window.devicePixelRatio||1);
+    const r=el.map.getBoundingClientRect();
+    view.w=Math.floor(r.width); view.h=Math.floor(r.height);
+    el.map.width=view.w*view.dpr; el.map.height=view.h*view.dpr;
+    ctx.setTransform(view.dpr,0,0,view.dpr,0,0);
+    render();
+  }
+  function init(){
+    el.status.textContent='Grounded'; el.status.className='status neutral';
+    app.drones = Array.from({length:CFG.COUNT},(_,i)=>createDrone(i));
+    resize(); updateUI(); bind(); requestAnimationFrame(loop);
+  }
+  init();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add the provided interactive SWARM PANEL experience at /swarm/
- wire the new CTA link into the navigation across all static pages and style the button state
- scope the hero background image to the home page by applying a .home body class

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68cea6e9468083258242d607522d1242