### PR TITLE
Fix SWARM PANEL nav link to use relative URL

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/founder.html
+++ b/founder.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/overview.html
+++ b/overview.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/panel.html
+++ b/panel.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>

--- a/research.html
+++ b/research.html
@@ -23,7 +23,7 @@
             <ul class="nav__list">
               <li><a href="overview.html" class="nav__link">Overview</a></li>
               <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="/swarm/" data-nav="swarm">SWARM PANEL</a></li>
+              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
               <li><a href="research.html" class="nav__link">Research</a></li>
               <li><a href="contact.html" class="nav__link">Contact</a></li>
             </ul>


### PR DESCRIPTION
## Summary
- update the SWARM PANEL navigation link across site pages to use a relative path so it works on GitHub Pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceaccc1518832597231291d90c6e1f