### PR TITLE
Replace header with brand dropdown

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -8,6 +8,39 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <header class="site-bar">
+      <details class="brand-menu" role="navigation">
+        <summary class="brand-pill" aria-label="Open site menu">
+          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+          <span class="brand-text">Contact</span>
+          <span class="caret">▾</span>
+        </summary>
+        <nav class="brand-dropdown" aria-label="Main">
+          <a href="overview.html">Overview</a>
+          <a href="swarm/">Swarm Panel</a>
+          <a href="research.html">Research</a>
+          <a href="contact.html">Contact</a>
+          <a href="javascript:history.back()">Back</a>
+        </nav>
+      </details>
+    </header>
+    <script>
+      (function(){
+        const menu = document.querySelector('.brand-menu');
+        if(!menu) return;
+
+        // Close when clicking outside
+        document.addEventListener('click', (e)=>{
+          if(!menu.open) return;
+          if(!menu.contains(e.target)) menu.open = false;
+        });
+
+        // Close on Escape
+        document.addEventListener('keydown', (e)=>{
+          if(e.key === 'Escape') menu.open = false;
+        });
+      })();
+    </script>
     <main role="main">
       <section class="hero hero--framed hero--plain">
         <div class="hero__bg" aria-hidden="true"></div>
@@ -15,20 +48,6 @@
           <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
           <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
         </a>
-        <nav class="hero__nav" aria-label="Site">
-          <button class="nav__toggle" aria-expanded="false" aria-controls="navPanel">
-            MENU ▾
-          </button>
-          <div class="nav__panel" id="navPanel" hidden>
-            <ul class="nav__list">
-              <li><a href="overview.html" class="nav__link">Overview</a></li>
-              <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
-              <li><a href="research.html" class="nav__link">Research</a></li>
-              <li><a href="contact.html" class="nav__link">Contact</a></li>
-            </ul>
-          </div>
-        </nav>
         <div class="hero__subbadge"><p class="title">Contact</p></div>
       </section>
     </main>
@@ -45,52 +64,6 @@
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>
     <script>
       document.getElementById("current-year").textContent = new Date().getFullYear();
-    </script>
-    <script>
-      (function(){
-        const btn = document.querySelector('.nav__toggle');
-        const panel = document.getElementById('navPanel');
-        if(!btn || !panel) return;
-
-        function placePanel(){
-          const r = btn.getBoundingClientRect();
-          // fixed so it’s not clipped by hero overflow
-          panel.style.position = 'fixed';
-          panel.style.top = (r.bottom + 8) + 'px';
-          // align the panel’s right edge with the button’s right edge
-          panel.style.left = 'auto';
-          panel.style.right = Math.max(12, window.innerWidth - (r.right)) + 'px';
-          panel.style.zIndex = '9999';
-        }
-
-        function openPanel(){
-          panel.hidden = false;
-          placePanel();
-          // let CSS handle fade-in
-          requestAnimationFrame(()=> panel.setAttribute('data-open','true'));
-          btn.setAttribute('aria-expanded','true');
-        }
-        function closePanel(){
-          panel.removeAttribute('data-open');
-          panel.addEventListener('transitionend', ()=>{
-            panel.hidden = true;
-            panel.removeAttribute('style');
-          }, {once:true});
-          btn.setAttribute('aria-expanded','false');
-        }
-
-        let open = false;
-        btn.addEventListener('click', ()=>{
-          open ? closePanel() : openPanel();
-          open = !open;
-        });
-        window.addEventListener('resize', ()=>{ if(open){ placePanel(); } });
-        document.addEventListener('click', (e)=>{
-          if(!open) return;
-          if(!panel.contains(e.target) && e.target !== btn){ open = false; closePanel(); }
-        });
-        document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && open){ open=false; closePanel(); }});
-      })();
     </script>
     <script>
       (function(){

--- a/founder.html
+++ b/founder.html
@@ -8,6 +8,39 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <header class="site-bar">
+      <details class="brand-menu" role="navigation">
+        <summary class="brand-pill" aria-label="Open site menu">
+          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+          <span class="brand-text">Founder</span>
+          <span class="caret">▾</span>
+        </summary>
+        <nav class="brand-dropdown" aria-label="Main">
+          <a href="overview.html">Overview</a>
+          <a href="swarm/">Swarm Panel</a>
+          <a href="research.html">Research</a>
+          <a href="contact.html">Contact</a>
+          <a href="javascript:history.back()">Back</a>
+        </nav>
+      </details>
+    </header>
+    <script>
+      (function(){
+        const menu = document.querySelector('.brand-menu');
+        if(!menu) return;
+
+        // Close when clicking outside
+        document.addEventListener('click', (e)=>{
+          if(!menu.open) return;
+          if(!menu.contains(e.target)) menu.open = false;
+        });
+
+        // Close on Escape
+        document.addEventListener('keydown', (e)=>{
+          if(e.key === 'Escape') menu.open = false;
+        });
+      })();
+    </script>
     <main role="main">
       <section class="hero hero--framed hero--plain">
         <div class="hero__bg" aria-hidden="true"></div>
@@ -15,20 +48,6 @@
           <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
           <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
         </a>
-        <nav class="hero__nav" aria-label="Site">
-          <button class="nav__toggle" aria-expanded="false" aria-controls="navPanel">
-            MENU ▾
-          </button>
-          <div class="nav__panel" id="navPanel" hidden>
-            <ul class="nav__list">
-              <li><a href="overview.html" class="nav__link">Overview</a></li>
-              <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
-              <li><a href="research.html" class="nav__link">Research</a></li>
-              <li><a href="contact.html" class="nav__link">Contact</a></li>
-            </ul>
-          </div>
-        </nav>
         <div class="hero__subbadge"><p class="title">Founder</p></div>
       </section>
     </main>
@@ -42,52 +61,6 @@
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>
     <script>
       document.getElementById("current-year").textContent = new Date().getFullYear();
-    </script>
-    <script>
-      (function(){
-        const btn = document.querySelector('.nav__toggle');
-        const panel = document.getElementById('navPanel');
-        if(!btn || !panel) return;
-
-        function placePanel(){
-          const r = btn.getBoundingClientRect();
-          // fixed so it’s not clipped by hero overflow
-          panel.style.position = 'fixed';
-          panel.style.top = (r.bottom + 8) + 'px';
-          // align the panel’s right edge with the button’s right edge
-          panel.style.left = 'auto';
-          panel.style.right = Math.max(12, window.innerWidth - (r.right)) + 'px';
-          panel.style.zIndex = '9999';
-        }
-
-        function openPanel(){
-          panel.hidden = false;
-          placePanel();
-          // let CSS handle fade-in
-          requestAnimationFrame(()=> panel.setAttribute('data-open','true'));
-          btn.setAttribute('aria-expanded','true');
-        }
-        function closePanel(){
-          panel.removeAttribute('data-open');
-          panel.addEventListener('transitionend', ()=>{
-            panel.hidden = true;
-            panel.removeAttribute('style');
-          }, {once:true});
-          btn.setAttribute('aria-expanded','false');
-        }
-
-        let open = false;
-        btn.addEventListener('click', ()=>{
-          open ? closePanel() : openPanel();
-          open = !open;
-        });
-        window.addEventListener('resize', ()=>{ if(open){ placePanel(); } });
-        document.addEventListener('click', (e)=>{
-          if(!open) return;
-          if(!panel.contains(e.target) && e.target !== btn){ open = false; closePanel(); }
-        });
-        document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && open){ open=false; closePanel(); }});
-      })();
     </script>
     <script>
       (function(){

--- a/index.html
+++ b/index.html
@@ -8,6 +8,39 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body class="home">
+    <header class="site-bar">
+      <details class="brand-menu" role="navigation">
+        <summary class="brand-pill" aria-label="Open site menu">
+          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+          <span class="brand-text">BLACK-HIVE</span>
+          <span class="caret">▾</span>
+        </summary>
+        <nav class="brand-dropdown" aria-label="Main">
+          <a href="overview.html">Overview</a>
+          <a href="swarm/">Swarm Panel</a>
+          <a href="research.html">Research</a>
+          <a href="contact.html">Contact</a>
+          <a href="javascript:history.back()">Back</a>
+        </nav>
+      </details>
+    </header>
+    <script>
+      (function(){
+        const menu = document.querySelector('.brand-menu');
+        if(!menu) return;
+
+        // Close when clicking outside
+        document.addEventListener('click', (e)=>{
+          if(!menu.open) return;
+          if(!menu.contains(e.target)) menu.open = false;
+        });
+
+        // Close on Escape
+        document.addEventListener('keydown', (e)=>{
+          if(e.key === 'Escape') menu.open = false;
+        });
+      })();
+    </script>
     <main role="main">
       <section class="hero hero--framed">
         <div class="hero__bg" aria-hidden="true"></div>
@@ -15,20 +48,6 @@
           <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
           <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
         </a>
-        <nav class="hero__nav" aria-label="Site">
-          <button class="nav__menu-btn" aria-expanded="false" aria-controls="navPanel">
-            MENU ▾
-          </button>
-          <div class="nav__panel" id="navPanel" hidden>
-            <ul class="nav__list">
-              <li><a href="overview.html" class="nav__link">Overview</a></li>
-              <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
-              <li><a href="research.html" class="nav__link">Research</a></li>
-              <li><a href="contact.html" class="nav__link">Contact</a></li>
-            </ul>
-          </div>
-        </nav>
         <div class="hero__banner" role="region" aria-label="Primary Call to Action">
           <div class="banner__row">
             <p class="banner__title">BLACK-HIVE: Tactical Swarm Systems</p>
@@ -44,52 +63,6 @@
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>
     <script>
       document.getElementById("current-year").textContent = new Date().getFullYear();
-    </script>
-    <script>
-      (function(){
-        const btn = document.querySelector('.nav__menu-btn');
-        const panel = document.getElementById('navPanel');
-        if(!btn || !panel) return;
-
-        function placePanel(){
-          const r = btn.getBoundingClientRect();
-          // fixed so it’s not clipped by hero overflow
-          panel.style.position = 'fixed';
-          panel.style.top = (r.bottom + 8) + 'px';
-          // align the panel’s right edge with the button’s right edge
-          panel.style.left = 'auto';
-          panel.style.right = Math.max(12, window.innerWidth - (r.right)) + 'px';
-          panel.style.zIndex = '9999';
-        }
-
-        function openPanel(){
-          panel.hidden = false;
-          placePanel();
-          // let CSS handle fade-in
-          requestAnimationFrame(()=> panel.setAttribute('data-open','true'));
-          btn.setAttribute('aria-expanded','true');
-        }
-        function closePanel(){
-          panel.removeAttribute('data-open');
-          panel.addEventListener('transitionend', ()=>{
-            panel.hidden = true;
-            panel.removeAttribute('style');
-          }, {once:true});
-          btn.setAttribute('aria-expanded','false');
-        }
-
-        let open = false;
-        btn.addEventListener('click', ()=>{
-          open ? closePanel() : openPanel();
-          open = !open;
-        });
-        window.addEventListener('resize', ()=>{ if(open){ placePanel(); } });
-        document.addEventListener('click', (e)=>{
-          if(!open) return;
-          if(!panel.contains(e.target) && e.target !== btn){ open = false; closePanel(); }
-        });
-        document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && open){ open=false; closePanel(); }});
-      })();
     </script>
     <script>
       (function(){

--- a/overview.html
+++ b/overview.html
@@ -8,6 +8,39 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <header class="site-bar">
+      <details class="brand-menu" role="navigation">
+        <summary class="brand-pill" aria-label="Open site menu">
+          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+          <span class="brand-text">Overview</span>
+          <span class="caret">▾</span>
+        </summary>
+        <nav class="brand-dropdown" aria-label="Main">
+          <a href="overview.html">Overview</a>
+          <a href="swarm/">Swarm Panel</a>
+          <a href="research.html">Research</a>
+          <a href="contact.html">Contact</a>
+          <a href="javascript:history.back()">Back</a>
+        </nav>
+      </details>
+    </header>
+    <script>
+      (function(){
+        const menu = document.querySelector('.brand-menu');
+        if(!menu) return;
+
+        // Close when clicking outside
+        document.addEventListener('click', (e)=>{
+          if(!menu.open) return;
+          if(!menu.contains(e.target)) menu.open = false;
+        });
+
+        // Close on Escape
+        document.addEventListener('keydown', (e)=>{
+          if(e.key === 'Escape') menu.open = false;
+        });
+      })();
+    </script>
     <main role="main">
       <section class="hero hero--framed hero--plain">
         <div class="hero__bg" aria-hidden="true"></div>
@@ -15,20 +48,6 @@
           <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
           <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
         </a>
-        <nav class="hero__nav" aria-label="Site">
-          <button class="nav__toggle" aria-expanded="false" aria-controls="navPanel">
-            MENU ▾
-          </button>
-          <div class="nav__panel" id="navPanel" hidden>
-            <ul class="nav__list">
-              <li><a href="overview.html" class="nav__link">Overview</a></li>
-              <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
-              <li><a href="research.html" class="nav__link">Research</a></li>
-              <li><a href="contact.html" class="nav__link">Contact</a></li>
-            </ul>
-          </div>
-        </nav>
         <div class="hero__subbadge"><p class="title">Overview</p></div>
       </section>
     </main>
@@ -46,52 +65,6 @@
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>
     <script>
       document.getElementById("current-year").textContent = new Date().getFullYear();
-    </script>
-    <script>
-      (function(){
-        const btn = document.querySelector('.nav__toggle');
-        const panel = document.getElementById('navPanel');
-        if(!btn || !panel) return;
-
-        function placePanel(){
-          const r = btn.getBoundingClientRect();
-          // fixed so it’s not clipped by hero overflow
-          panel.style.position = 'fixed';
-          panel.style.top = (r.bottom + 8) + 'px';
-          // align the panel’s right edge with the button’s right edge
-          panel.style.left = 'auto';
-          panel.style.right = Math.max(12, window.innerWidth - (r.right)) + 'px';
-          panel.style.zIndex = '9999';
-        }
-
-        function openPanel(){
-          panel.hidden = false;
-          placePanel();
-          // let CSS handle fade-in
-          requestAnimationFrame(()=> panel.setAttribute('data-open','true'));
-          btn.setAttribute('aria-expanded','true');
-        }
-        function closePanel(){
-          panel.removeAttribute('data-open');
-          panel.addEventListener('transitionend', ()=>{
-            panel.hidden = true;
-            panel.removeAttribute('style');
-          }, {once:true});
-          btn.setAttribute('aria-expanded','false');
-        }
-
-        let open = false;
-        btn.addEventListener('click', ()=>{
-          open ? closePanel() : openPanel();
-          open = !open;
-        });
-        window.addEventListener('resize', ()=>{ if(open){ placePanel(); } });
-        document.addEventListener('click', (e)=>{
-          if(!open) return;
-          if(!panel.contains(e.target) && e.target !== btn){ open = false; closePanel(); }
-        });
-        document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && open){ open=false; closePanel(); }});
-      })();
     </script>
     <script>
       (function(){

--- a/panel.html
+++ b/panel.html
@@ -8,6 +8,39 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <header class="site-bar">
+      <details class="brand-menu" role="navigation">
+        <summary class="brand-pill" aria-label="Open site menu">
+          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+          <span class="brand-text">Swarm Panel</span>
+          <span class="caret">▾</span>
+        </summary>
+        <nav class="brand-dropdown" aria-label="Main">
+          <a href="overview.html">Overview</a>
+          <a href="swarm/">Swarm Panel</a>
+          <a href="research.html">Research</a>
+          <a href="contact.html">Contact</a>
+          <a href="javascript:history.back()">Back</a>
+        </nav>
+      </details>
+    </header>
+    <script>
+      (function(){
+        const menu = document.querySelector('.brand-menu');
+        if(!menu) return;
+
+        // Close when clicking outside
+        document.addEventListener('click', (e)=>{
+          if(!menu.open) return;
+          if(!menu.contains(e.target)) menu.open = false;
+        });
+
+        // Close on Escape
+        document.addEventListener('keydown', (e)=>{
+          if(e.key === 'Escape') menu.open = false;
+        });
+      })();
+    </script>
     <main role="main">
       <section class="hero hero--framed hero--plain">
         <div class="hero__bg" aria-hidden="true"></div>
@@ -15,20 +48,6 @@
           <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
           <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
         </a>
-        <nav class="hero__nav" aria-label="Site">
-          <button class="nav__toggle" aria-expanded="false" aria-controls="navPanel">
-            MENU ▾
-          </button>
-          <div class="nav__panel" id="navPanel" hidden>
-            <ul class="nav__list">
-              <li><a href="overview.html" class="nav__link">Overview</a></li>
-              <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
-              <li><a href="research.html" class="nav__link">Research</a></li>
-              <li><a href="contact.html" class="nav__link">Contact</a></li>
-            </ul>
-          </div>
-        </nav>
         <div class="hero__subbadge"><p class="title">SWARM PANEL</p></div>
       </section>
     </main>
@@ -41,52 +60,6 @@
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>
     <script>
       document.getElementById("current-year").textContent = new Date().getFullYear();
-    </script>
-    <script>
-      (function(){
-        const btn = document.querySelector('.nav__toggle');
-        const panel = document.getElementById('navPanel');
-        if(!btn || !panel) return;
-
-        function placePanel(){
-          const r = btn.getBoundingClientRect();
-          // fixed so it’s not clipped by hero overflow
-          panel.style.position = 'fixed';
-          panel.style.top = (r.bottom + 8) + 'px';
-          // align the panel’s right edge with the button’s right edge
-          panel.style.left = 'auto';
-          panel.style.right = Math.max(12, window.innerWidth - (r.right)) + 'px';
-          panel.style.zIndex = '9999';
-        }
-
-        function openPanel(){
-          panel.hidden = false;
-          placePanel();
-          // let CSS handle fade-in
-          requestAnimationFrame(()=> panel.setAttribute('data-open','true'));
-          btn.setAttribute('aria-expanded','true');
-        }
-        function closePanel(){
-          panel.removeAttribute('data-open');
-          panel.addEventListener('transitionend', ()=>{
-            panel.hidden = true;
-            panel.removeAttribute('style');
-          }, {once:true});
-          btn.setAttribute('aria-expanded','false');
-        }
-
-        let open = false;
-        btn.addEventListener('click', ()=>{
-          open ? closePanel() : openPanel();
-          open = !open;
-        });
-        window.addEventListener('resize', ()=>{ if(open){ placePanel(); } });
-        document.addEventListener('click', (e)=>{
-          if(!open) return;
-          if(!panel.contains(e.target) && e.target !== btn){ open = false; closePanel(); }
-        });
-        document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && open){ open=false; closePanel(); }});
-      })();
     </script>
     <script>
       (function(){

--- a/research.html
+++ b/research.html
@@ -8,6 +8,39 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <header class="site-bar">
+      <details class="brand-menu" role="navigation">
+        <summary class="brand-pill" aria-label="Open site menu">
+          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+          <span class="brand-text">Research</span>
+          <span class="caret">▾</span>
+        </summary>
+        <nav class="brand-dropdown" aria-label="Main">
+          <a href="overview.html">Overview</a>
+          <a href="swarm/">Swarm Panel</a>
+          <a href="research.html">Research</a>
+          <a href="contact.html">Contact</a>
+          <a href="javascript:history.back()">Back</a>
+        </nav>
+      </details>
+    </header>
+    <script>
+      (function(){
+        const menu = document.querySelector('.brand-menu');
+        if(!menu) return;
+
+        // Close when clicking outside
+        document.addEventListener('click', (e)=>{
+          if(!menu.open) return;
+          if(!menu.contains(e.target)) menu.open = false;
+        });
+
+        // Close on Escape
+        document.addEventListener('keydown', (e)=>{
+          if(e.key === 'Escape') menu.open = false;
+        });
+      })();
+    </script>
     <main role="main">
       <section class="hero hero--framed hero--plain">
         <div class="hero__bg" aria-hidden="true"></div>
@@ -15,20 +48,6 @@
           <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
           <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
         </a>
-        <nav class="hero__nav" aria-label="Site">
-          <button class="nav__toggle" aria-expanded="false" aria-controls="navPanel">
-            MENU ▾
-          </button>
-          <div class="nav__panel" id="navPanel" hidden>
-            <ul class="nav__list">
-              <li><a href="overview.html" class="nav__link">Overview</a></li>
-              <li><a href="founder.html" class="nav__link">Founder</a></li>
-              <li><a class="nav__link nav__link--cta" href="swarm/" data-nav="swarm">SWARM PANEL</a></li>
-              <li><a href="research.html" class="nav__link">Research</a></li>
-              <li><a href="contact.html" class="nav__link">Contact</a></li>
-            </ul>
-          </div>
-        </nav>
         <div class="hero__subbadge"><p class="title">Research</p></div>
       </section>
     </main>
@@ -42,52 +61,6 @@
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>
     <script>
       document.getElementById("current-year").textContent = new Date().getFullYear();
-    </script>
-    <script>
-      (function(){
-        const btn = document.querySelector('.nav__toggle');
-        const panel = document.getElementById('navPanel');
-        if(!btn || !panel) return;
-
-        function placePanel(){
-          const r = btn.getBoundingClientRect();
-          // fixed so it’s not clipped by hero overflow
-          panel.style.position = 'fixed';
-          panel.style.top = (r.bottom + 8) + 'px';
-          // align the panel’s right edge with the button’s right edge
-          panel.style.left = 'auto';
-          panel.style.right = Math.max(12, window.innerWidth - (r.right)) + 'px';
-          panel.style.zIndex = '9999';
-        }
-
-        function openPanel(){
-          panel.hidden = false;
-          placePanel();
-          // let CSS handle fade-in
-          requestAnimationFrame(()=> panel.setAttribute('data-open','true'));
-          btn.setAttribute('aria-expanded','true');
-        }
-        function closePanel(){
-          panel.removeAttribute('data-open');
-          panel.addEventListener('transitionend', ()=>{
-            panel.hidden = true;
-            panel.removeAttribute('style');
-          }, {once:true});
-          btn.setAttribute('aria-expanded','false');
-        }
-
-        let open = false;
-        btn.addEventListener('click', ()=>{
-          open ? closePanel() : openPanel();
-          open = !open;
-        });
-        window.addEventListener('resize', ()=>{ if(open){ placePanel(); } });
-        document.addEventListener('click', (e)=>{
-          if(!open) return;
-          if(!panel.contains(e.target) && e.target !== btn){ open = false; closePanel(); }
-        });
-        document.addEventListener('keydown', (e)=>{ if(e.key==='Escape' && open){ open=false; closePanel(); }});
-      })();
     </script>
     <script>
       (function(){

--- a/style.css
+++ b/style.css
@@ -36,6 +36,44 @@ main {
   flex: 1;
 }
 
+/* Top bar container */
+.site-bar{
+  max-width:1200px; margin:10px auto 0; padding:0 10px;
+  display:flex; align-items:center; justify-content:flex-start;
+}
+
+/* The single pill that shows logo + text and opens the dropdown */
+.brand-pill{
+  display:flex; align-items:center; gap:10px;
+  background:#d0d3d7; color:#111; padding:10px 14px;
+  border:1px solid rgba(0,0,0,.08); border-radius:14px;
+  font-weight:800; letter-spacing:.4px; user-select:none; cursor:pointer;
+}
+.brand-pill:hover{ filter:brightness(0.96); }
+.brand-logo{ height:22px; width:auto; }
+.brand-text{ font-weight:900; text-transform:uppercase; }
+.caret{ margin-left:6px; opacity:.7 }
+
+/* Dropdown */
+.brand-menu{ position:relative }
+.brand-menu[open] .brand-pill{ outline:1px dashed #bbb; outline-offset:2px }
+.brand-dropdown{
+  position:absolute; left:0; top:calc(100% + 8px); z-index:20;
+  background:#0f151c; color:#e8f1fb;
+  border:1px solid #1b2430; border-radius:12px; min-width:230px; padding:8px;
+  box-shadow:0 10px 26px rgba(0,0,0,.35);
+}
+.brand-dropdown a{
+  display:block; padding:8px 10px; border-radius:8px; color:#e8f1fb; text-decoration:none;
+}
+.brand-dropdown a:hover{ background:#0c1116 }
+
+/* Small screens */
+@media (max-width:600px){
+  .brand-text{ font-size:12px }
+  .brand-logo{ height:20px }
+}
+
 .hero {
   position: relative; /* keep existing as-is */
   min-height: 100vh;

--- a/swarm/index.html
+++ b/swarm/index.html
@@ -81,56 +81,79 @@
   :focus-visible{outline:2px solid rgba(255,255,255,.25);outline-offset:2px;border-radius:6px}
   @media (prefers-reduced-motion: reduce){*{animation:none!important;transition:none!important}}
 
+  /* Top bar container */
   .site-bar{
     max-width:1200px; margin:10px auto 0; padding:0 10px;
-    display:flex; align-items:center; justify-content:space-between; gap:10px;
+    display:flex; align-items:center; justify-content:flex-start;
   }
 
-  .brand-pill, .menu-pill > summary{
+  /* The single pill that shows logo + text and opens the dropdown */
+  .brand-pill{
     display:flex; align-items:center; gap:10px;
     background:#d0d3d7; color:#111; padding:10px 14px;
-    border-radius:14px; font-weight:800; letter-spacing:.4px;
-    border:1px solid rgba(0,0,0,.08); cursor:pointer; user-select:none;
-    list-style:none;
+    border:1px solid rgba(0,0,0,.08); border-radius:14px;
+    font-weight:800; letter-spacing:.4px; user-select:none; cursor:pointer;
   }
-  .brand-pill:hover, .menu-pill > summary:hover{ filter:brightness(0.96); }
-
+  .brand-pill:hover{ filter:brightness(0.96); }
   .brand-logo{ height:22px; width:auto; }
   .brand-text{ font-weight:900; text-transform:uppercase; }
+  .caret{ margin-left:6px; opacity:.7 }
 
-  .menu-pill{ position:relative; }
-  .menu-pill[open] > summary{ outline:1px dashed #bbb; }
-  .menu-pill > summary::-webkit-details-marker{ display:none; }
-  .menu-pill > nav{
-    position:absolute; right:0; top:calc(100% + 8px);
-    background:#0f151c; color:#e8f1fb; border:1px solid #1b2430;
-    border-radius:12px; min-width:210px; padding:8px; z-index:20;
+  /* Dropdown */
+  .brand-menu{ position:relative }
+  .brand-menu[open] .brand-pill{ outline:1px dashed #bbb; outline-offset:2px }
+  .brand-dropdown{
+    position:absolute; left:0; top:calc(100% + 8px); z-index:20;
+    background:#0f151c; color:#e8f1fb;
+    border:1px solid #1b2430; border-radius:12px; min-width:230px; padding:8px;
     box-shadow:0 10px 26px rgba(0,0,0,.35);
   }
-  .menu-pill > nav a{
-    display:block; padding:8px 10px; border-radius:8px; text-decoration:none; color:#e8f1fb;
+  .brand-dropdown a{
+    display:block; padding:8px 10px; border-radius:8px; color:#e8f1fb; text-decoration:none;
   }
-  .menu-pill > nav a:hover{ background:#0c1116; }
+  .brand-dropdown a:hover{ background:#0c1116 }
+
+  /* Small screens */
+  @media (max-width:600px){
+    .brand-text{ font-size:12px }
+    .brand-logo{ height:20px }
+  }
 </style>
 </head>
 <body>
   <header class="site-bar">
-    <a class="brand-pill" href="../index.html">
-      <img src="../assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
-      <span class="brand-text">SWARM PANEL</span>
-    </a>
-
-    <details class="menu-pill">
-      <summary>MENU ▾</summary>
-      <nav>
-        <a href="../index.html#overview">Overview</a>
-        <a href="../index.html#swarm">Swarm Panel</a>
-        <a href="../index.html#research">Research</a>
-        <a href="../index.html#contact">Contact</a>
+    <details class="brand-menu" role="navigation">
+      <summary class="brand-pill" aria-label="Open site menu">
+        <img src="../assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+        <span class="brand-text">Swarm Panel</span>
+        <span class="caret">▾</span>
+      </summary>
+      <nav class="brand-dropdown" aria-label="Main">
+        <a href="../overview.html">Overview</a>
+        <a href="./index.html">Swarm Panel</a>
+        <a href="../research.html">Research</a>
+        <a href="../contact.html">Contact</a>
         <a href="javascript:history.back()">Back</a>
       </nav>
     </details>
   </header>
+  <script>
+    (function(){
+      const menu = document.querySelector('.brand-menu');
+      if(!menu) return;
+
+      // Close when clicking outside
+      document.addEventListener('click', (e)=>{
+        if(!menu.open) return;
+        if(!menu.contains(e.target)) menu.open = false;
+      });
+
+      // Close on Escape
+      document.addEventListener('keydown', (e)=>{
+        if(e.key === 'Escape') menu.open = false;
+      });
+    })();
+  </script>
 
   <div class="wrap">
     <!-- LEFT -->


### PR DESCRIPTION
## Summary
- add the new brand dropdown header to each marketing page and the swarm panel
- remove the legacy MENU pill so the logo pill acts as the navigation trigger
- update shared styles and scripts so the dropdown closes on outside click or Escape

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cec0bb07a083258f02f3932e6cda62