### PR TITLE
Move nav dropdown into hero and remove static logo

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -8,22 +8,28 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header class="site-bar">
-      <details class="brand-menu" role="navigation">
-        <summary class="brand-pill" aria-label="Open site menu">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
-          <span class="brand-text">Contact</span>
-          <span class="caret">▾</span>
-        </summary>
-        <nav class="brand-dropdown" aria-label="Main">
-          <a href="overview.html">Overview</a>
-          <a href="swarm/">Swarm Panel</a>
-          <a href="research.html">Research</a>
-          <a href="contact.html">Contact</a>
-          <a href="javascript:history.back()">Back</a>
-        </nav>
-      </details>
-    </header>
+    <main role="main">
+      <section class="hero hero--framed hero--plain">
+        <div class="hero__bg" aria-hidden="true"></div>
+        <header class="site-bar">
+          <details class="brand-menu" role="navigation">
+            <summary class="brand-pill" aria-label="Open site menu">
+              <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+              <span class="brand-text">Contact</span>
+              <span class="caret">▾</span>
+            </summary>
+            <nav class="brand-dropdown" aria-label="Main">
+              <a href="overview.html">Overview</a>
+              <a href="swarm/">Swarm Panel</a>
+              <a href="research.html">Research</a>
+              <a href="contact.html">Contact</a>
+              <a href="javascript:history.back()">Back</a>
+            </nav>
+          </details>
+        </header>
+        <div class="hero__subbadge"><p class="title">Contact</p></div>
+      </section>
+    </main>
     <script>
       (function(){
         const menu = document.querySelector('.brand-menu');
@@ -41,16 +47,6 @@
         });
       })();
     </script>
-    <main role="main">
-      <section class="hero hero--framed hero--plain">
-        <div class="hero__bg" aria-hidden="true"></div>
-        <a class="hero__brand" href="index.html" aria-label="BLACK-HIVE">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
-          <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
-        </a>
-        <div class="hero__subbadge"><p class="title">Contact</p></div>
-      </section>
-    </main>
     <main class="content">
       <section>
         <h1>Contact</h1>

--- a/founder.html
+++ b/founder.html
@@ -8,22 +8,28 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header class="site-bar">
-      <details class="brand-menu" role="navigation">
-        <summary class="brand-pill" aria-label="Open site menu">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
-          <span class="brand-text">Founder</span>
-          <span class="caret">▾</span>
-        </summary>
-        <nav class="brand-dropdown" aria-label="Main">
-          <a href="overview.html">Overview</a>
-          <a href="swarm/">Swarm Panel</a>
-          <a href="research.html">Research</a>
-          <a href="contact.html">Contact</a>
-          <a href="javascript:history.back()">Back</a>
-        </nav>
-      </details>
-    </header>
+    <main role="main">
+      <section class="hero hero--framed hero--plain">
+        <div class="hero__bg" aria-hidden="true"></div>
+        <header class="site-bar">
+          <details class="brand-menu" role="navigation">
+            <summary class="brand-pill" aria-label="Open site menu">
+              <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+              <span class="brand-text">Founder</span>
+              <span class="caret">▾</span>
+            </summary>
+            <nav class="brand-dropdown" aria-label="Main">
+              <a href="overview.html">Overview</a>
+              <a href="swarm/">Swarm Panel</a>
+              <a href="research.html">Research</a>
+              <a href="contact.html">Contact</a>
+              <a href="javascript:history.back()">Back</a>
+            </nav>
+          </details>
+        </header>
+        <div class="hero__subbadge"><p class="title">Founder</p></div>
+      </section>
+    </main>
     <script>
       (function(){
         const menu = document.querySelector('.brand-menu');
@@ -41,16 +47,6 @@
         });
       })();
     </script>
-    <main role="main">
-      <section class="hero hero--framed hero--plain">
-        <div class="hero__bg" aria-hidden="true"></div>
-        <a class="hero__brand" href="index.html" aria-label="BLACK-HIVE">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
-          <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
-        </a>
-        <div class="hero__subbadge"><p class="title">Founder</p></div>
-      </section>
-    </main>
     <main class="content">
       <section>
         <h1>Founder</h1>

--- a/index.html
+++ b/index.html
@@ -8,22 +8,37 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body class="home">
-    <header class="site-bar">
-      <details class="brand-menu" role="navigation">
-        <summary class="brand-pill" aria-label="Open site menu">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
-          <span class="brand-text">BLACK-HIVE</span>
-          <span class="caret">▾</span>
-        </summary>
-        <nav class="brand-dropdown" aria-label="Main">
-          <a href="overview.html">Overview</a>
-          <a href="swarm/">Swarm Panel</a>
-          <a href="research.html">Research</a>
-          <a href="contact.html">Contact</a>
-          <a href="javascript:history.back()">Back</a>
-        </nav>
-      </details>
-    </header>
+    <main role="main">
+      <section class="hero hero--framed">
+        <div class="hero__bg" aria-hidden="true"></div>
+        <header class="site-bar">
+          <details class="brand-menu" role="navigation">
+            <summary class="brand-pill" aria-label="Open site menu">
+              <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+              <span class="brand-text">BLACK-HIVE</span>
+              <span class="caret">▾</span>
+            </summary>
+            <nav class="brand-dropdown" aria-label="Main">
+              <a href="overview.html">Overview</a>
+              <a href="swarm/">Swarm Panel</a>
+              <a href="research.html">Research</a>
+              <a href="contact.html">Contact</a>
+              <a href="javascript:history.back()">Back</a>
+            </nav>
+          </details>
+        </header>
+        <div class="hero__banner" role="region" aria-label="Primary Call to Action">
+          <div class="banner__row">
+            <p class="banner__title">BLACK-HIVE: Tactical Swarm Systems</p>
+            <p class="banner__desc">Exploring next-generation swarm coordination for security, events, and critical response.</p>
+            <div class="actions">
+              <a class="btn btn--primary" href="mailto:contact@blackhive.ai?subject=BLACK-HIVE%20Waitlist&body=Hi%20BLACK-HIVE%20team%2C%0A%0AI%27d%20like%20to%20join%20the%20waitlist.%20Please%20keep%20me%20posted.%0A%0AThanks!">Join Waitlist</a>
+              <a href="mailto:contact@blackhive.ai" class="btn btn--outline">Contact Us</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
     <script>
       (function(){
         const menu = document.querySelector('.brand-menu');
@@ -41,25 +56,6 @@
         });
       })();
     </script>
-    <main role="main">
-      <section class="hero hero--framed">
-        <div class="hero__bg" aria-hidden="true"></div>
-        <a class="hero__brand" href="index.html" aria-label="BLACK-HIVE">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
-          <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
-        </a>
-        <div class="hero__banner" role="region" aria-label="Primary Call to Action">
-          <div class="banner__row">
-            <p class="banner__title">BLACK-HIVE: Tactical Swarm Systems</p>
-            <p class="banner__desc">Exploring next-generation swarm coordination for security, events, and critical response.</p>
-            <div class="actions">
-              <a class="btn btn--primary" href="mailto:contact@blackhive.ai?subject=BLACK-HIVE%20Waitlist&body=Hi%20BLACK-HIVE%20team%2C%0A%0AI%27d%20like%20to%20join%20the%20waitlist.%20Please%20keep%20me%20posted.%0A%0AThanks!">Join Waitlist</a>
-              <a href="mailto:contact@blackhive.ai" class="btn btn--outline">Contact Us</a>
-            </div>
-          </div>
-        </div>
-      </section>
-    </main>
     <footer class="page-footer">© <span id="current-year"></span> BLACK-HIVE</footer>
     <script>
       document.getElementById("current-year").textContent = new Date().getFullYear();

--- a/overview.html
+++ b/overview.html
@@ -8,22 +8,28 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header class="site-bar">
-      <details class="brand-menu" role="navigation">
-        <summary class="brand-pill" aria-label="Open site menu">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
-          <span class="brand-text">Overview</span>
-          <span class="caret">▾</span>
-        </summary>
-        <nav class="brand-dropdown" aria-label="Main">
-          <a href="overview.html">Overview</a>
-          <a href="swarm/">Swarm Panel</a>
-          <a href="research.html">Research</a>
-          <a href="contact.html">Contact</a>
-          <a href="javascript:history.back()">Back</a>
-        </nav>
-      </details>
-    </header>
+    <main role="main">
+      <section class="hero hero--framed hero--plain">
+        <div class="hero__bg" aria-hidden="true"></div>
+        <header class="site-bar">
+          <details class="brand-menu" role="navigation">
+            <summary class="brand-pill" aria-label="Open site menu">
+              <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+              <span class="brand-text">Overview</span>
+              <span class="caret">▾</span>
+            </summary>
+            <nav class="brand-dropdown" aria-label="Main">
+              <a href="overview.html">Overview</a>
+              <a href="swarm/">Swarm Panel</a>
+              <a href="research.html">Research</a>
+              <a href="contact.html">Contact</a>
+              <a href="javascript:history.back()">Back</a>
+            </nav>
+          </details>
+        </header>
+        <div class="hero__subbadge"><p class="title">Overview</p></div>
+      </section>
+    </main>
     <script>
       (function(){
         const menu = document.querySelector('.brand-menu');
@@ -41,16 +47,6 @@
         });
       })();
     </script>
-    <main role="main">
-      <section class="hero hero--framed hero--plain">
-        <div class="hero__bg" aria-hidden="true"></div>
-        <a class="hero__brand" href="index.html" aria-label="BLACK-HIVE">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
-          <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
-        </a>
-        <div class="hero__subbadge"><p class="title">Overview</p></div>
-      </section>
-    </main>
     <main class="content">
       <section>
         <h1>Overview</h1>

--- a/panel.html
+++ b/panel.html
@@ -8,22 +8,28 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header class="site-bar">
-      <details class="brand-menu" role="navigation">
-        <summary class="brand-pill" aria-label="Open site menu">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
-          <span class="brand-text">Swarm Panel</span>
-          <span class="caret">▾</span>
-        </summary>
-        <nav class="brand-dropdown" aria-label="Main">
-          <a href="overview.html">Overview</a>
-          <a href="swarm/">Swarm Panel</a>
-          <a href="research.html">Research</a>
-          <a href="contact.html">Contact</a>
-          <a href="javascript:history.back()">Back</a>
-        </nav>
-      </details>
-    </header>
+    <main role="main">
+      <section class="hero hero--framed hero--plain">
+        <div class="hero__bg" aria-hidden="true"></div>
+        <header class="site-bar">
+          <details class="brand-menu" role="navigation">
+            <summary class="brand-pill" aria-label="Open site menu">
+              <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+              <span class="brand-text">Swarm Panel</span>
+              <span class="caret">▾</span>
+            </summary>
+            <nav class="brand-dropdown" aria-label="Main">
+              <a href="overview.html">Overview</a>
+              <a href="swarm/">Swarm Panel</a>
+              <a href="research.html">Research</a>
+              <a href="contact.html">Contact</a>
+              <a href="javascript:history.back()">Back</a>
+            </nav>
+          </details>
+        </header>
+        <div class="hero__subbadge"><p class="title">SWARM PANEL</p></div>
+      </section>
+    </main>
     <script>
       (function(){
         const menu = document.querySelector('.brand-menu');
@@ -41,16 +47,6 @@
         });
       })();
     </script>
-    <main role="main">
-      <section class="hero hero--framed hero--plain">
-        <div class="hero__bg" aria-hidden="true"></div>
-        <a class="hero__brand" href="index.html" aria-label="BLACK-HIVE">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
-          <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
-        </a>
-        <div class="hero__subbadge"><p class="title">SWARM PANEL</p></div>
-      </section>
-    </main>
     <main class="content">
       <section>
         <h1>SWARM Panel</h1>

--- a/research.html
+++ b/research.html
@@ -8,22 +8,28 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header class="site-bar">
-      <details class="brand-menu" role="navigation">
-        <summary class="brand-pill" aria-label="Open site menu">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
-          <span class="brand-text">Research</span>
-          <span class="caret">▾</span>
-        </summary>
-        <nav class="brand-dropdown" aria-label="Main">
-          <a href="overview.html">Overview</a>
-          <a href="swarm/">Swarm Panel</a>
-          <a href="research.html">Research</a>
-          <a href="contact.html">Contact</a>
-          <a href="javascript:history.back()">Back</a>
-        </nav>
-      </details>
-    </header>
+    <main role="main">
+      <section class="hero hero--framed hero--plain">
+        <div class="hero__bg" aria-hidden="true"></div>
+        <header class="site-bar">
+          <details class="brand-menu" role="navigation">
+            <summary class="brand-pill" aria-label="Open site menu">
+              <img src="assets/IMG_1753.png" alt="BLACK-HIVE" class="brand-logo">
+              <span class="brand-text">Research</span>
+              <span class="caret">▾</span>
+            </summary>
+            <nav class="brand-dropdown" aria-label="Main">
+              <a href="overview.html">Overview</a>
+              <a href="swarm/">Swarm Panel</a>
+              <a href="research.html">Research</a>
+              <a href="contact.html">Contact</a>
+              <a href="javascript:history.back()">Back</a>
+            </nav>
+          </details>
+        </header>
+        <div class="hero__subbadge"><p class="title">Research</p></div>
+      </section>
+    </main>
     <script>
       (function(){
         const menu = document.querySelector('.brand-menu');
@@ -41,16 +47,6 @@
         });
       })();
     </script>
-    <main role="main">
-      <section class="hero hero--framed hero--plain">
-        <div class="hero__bg" aria-hidden="true"></div>
-        <a class="hero__brand" href="index.html" aria-label="BLACK-HIVE">
-          <img src="assets/IMG_1753.png" alt="BLACK-HIVE logo" />
-          <span class="brand__word">BLACK<span class="brand__dash">-</span>HIVE</span>
-        </a>
-        <div class="hero__subbadge"><p class="title">Research</p></div>
-      </section>
-    </main>
     <main class="content">
       <section>
         <h1>Research</h1>

--- a/style.css
+++ b/style.css
@@ -38,8 +38,15 @@ main {
 
 /* Top bar container */
 .site-bar{
-  max-width:1200px; margin:10px auto 0; padding:0 10px;
-  display:flex; align-items:center; justify-content:flex-start;
+  position:absolute;
+  top:max(12px, env(safe-area-inset-top, 0px) + 12px);
+  left:max(12px, env(safe-area-inset-left, 0px) + 12px);
+  display:flex;
+  align-items:center;
+  justify-content:flex-start;
+  margin:0;
+  padding:0;
+  z-index:6;
 }
 
 /* The single pill that shows logo + text and opens the dropdown */
@@ -77,50 +84,6 @@ main {
 .hero {
   position: relative; /* keep existing as-is */
   min-height: 100vh;
-}
-
-.hero__brand {
-  position: absolute;
-  top: max(12px, env(safe-area-inset-top, 0px) + 12px);
-  left: max(12px, env(safe-area-inset-left, 0px) + 12px);
-  display: inline-block;
-  z-index: 5;
-  padding: 6px 10px;
-  border-radius: 10px;
-  background: rgba(0, 0, 0, 0.25);
-  backdrop-filter: blur(4px) saturate(1.1);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 16px;
-  height: 44px;
-  border-radius: 8px;
-  background: #d1d3d4;
-}
-
-.brand img {
-  height: 22px;
-}
-
-.brand span {
-  font: 700 14px / 1 Inter, system-ui, sans-serif;
-  letter-spacing: 1px;
-  color: #111;
-}
-
-.brand__text {
-  font: 700 14px / 1 Inter, system-ui, sans-serif;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  color: #111;
-}
-
-.hero__brand:hover {
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
 }
 
 .hero__bg {
@@ -268,7 +231,7 @@ main {
   margin: clamp(12px, 4vw, 24px) auto;
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 20px;
-  overflow: hidden;
+  overflow: visible;
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.35);
 }
 
@@ -292,6 +255,7 @@ section.hero.hero--framed {
   background-position: center 42% !important;
   background-repeat: no-repeat;
   will-change: transform;
+  border-radius: inherit;
 }
 
 @media (max-width: 600px) {
@@ -321,44 +285,9 @@ section.hero.hero--framed {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06),
     inset 0 -80px 120px rgba(0, 0, 0, 0.25);
   pointer-events: none;
+  border-radius: inherit;
 }
 
-.hero__brand {
-  position: absolute;
-  z-index: 5;
-  top: max(12px, env(safe-area-inset-top) + 12px);
-  left: max(12px, env(safe-area-inset-left) + 12px);
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-radius: 14px;
-  background: rgba(0, 0, 0, 0.28);
-  backdrop-filter: blur(6px) saturate(1.1);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  text-decoration: none;
-}
-
-.hero__brand img {
-  height: 28px;
-  display: block;
-}
-
-@media (min-width: 900px) {
-  .hero__brand img {
-    height: 32px;
-  }
-}
-
-.brand__word {
-  font: 800 16px / 1.1 Inter, system-ui, sans-serif;
-  letter-spacing: 0.14em;
-  color: var(--ink);
-}
-
-.brand__dash {
-  color: var(--accent);
-}
 
 .hero__banner {
   position: absolute;


### PR DESCRIPTION
## Summary
- embed the dropdown navigation header inside each hero section so it replaces the former static logo
- remove the redundant hero logo markup and keep the existing menu options intact across the site
- update hero styling so the repositioned navigation renders correctly without clipping

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1a2733cb4832591615819addfd66d