### PR TITLE
Overlay navigation pill on hero

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,28 +9,37 @@
     {% if page.head_extra %}{{ page.head_extra | safe }}{% endif %}
   </head>
   <body class="{% if page.body_class %}{{ page.body_class }}{% endif %}{% if page.hero %} has-hero{% endif %}">
-    <header class="site-header" role="banner">
-      <div class="site-header__inner">
-        <details class="brand-menu" role="navigation">
-          <summary class="brand-pill" aria-label="Open site menu">
-            <img src="{{ '/assets/IMG_1753.png' | relative_url }}" alt="{{ site.title }}" class="brand-logo" />
-            <span class="brand-text">{{ page.nav_label | default: page.title | default: site.title }}</span>
-            <span class="caret">▾</span>
-          </summary>
-          <nav class="brand-dropdown" aria-label="Main">
-            <a href="{{ '/overview.html' | relative_url }}">Overview</a>
-            <a href="{{ '/swarm/' | relative_url }}">Swarm Panel Sim</a>
-            <a href="{{ '/research.html' | relative_url }}">Research</a>
-            <a href="{{ '/contact.html' | relative_url }}">Contact</a>
-            <a href="javascript:history.back()">Back</a>
-          </nav>
-        </details>
-      </div>
-    </header>
+    {% capture brand_menu %}
+      <details class="brand-menu" role="navigation">
+        <summary class="brand-pill" aria-label="Open site menu">
+          <img src="{{ '/assets/IMG_1753.png' | relative_url }}" alt="{{ site.title }}" class="brand-logo" />
+          <span class="brand-text">{{ page.nav_label | default: page.title | default: site.title }}</span>
+          <span class="caret">▾</span>
+        </summary>
+        <nav class="brand-dropdown" aria-label="Main">
+          <a href="{{ '/overview.html' | relative_url }}">Overview</a>
+          <a href="{{ '/swarm/' | relative_url }}">Swarm Panel Sim</a>
+          <a href="{{ '/research.html' | relative_url }}">Research</a>
+          <a href="{{ '/contact.html' | relative_url }}">Contact</a>
+          <a href="javascript:history.back()">Back</a>
+        </nav>
+      </details>
+    {% endcapture %}
+
+    {% unless page.hero %}
+      <header class="site-header" role="banner">
+        <div class="site-header__inner">
+          {{ brand_menu | strip }}
+        </div>
+      </header>
+    {% endunless %}
 
     <main id="main-content" class="site-main" role="main">
       {% if page.hero %}
         <section class="hero hero--framed" aria-labelledby="hero-title">
+          <div class="hero__menu">
+            {{ brand_menu | strip }}
+          </div>
           <div class="hero__bg" aria-hidden="true"></div>
           <div class="hero__banner" role="region" aria-labelledby="hero-title">
             <div class="banner__row">

--- a/style.css
+++ b/style.css
@@ -88,6 +88,7 @@ summary::-webkit-details-marker {
   user-select: none;
   border: 1px solid rgba(0, 0, 0, 0.12);
   text-transform: uppercase;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
 }
 
 .brand-pill:hover {
@@ -149,15 +150,24 @@ summary::-webkit-details-marker {
   align-items: stretch;
 }
 
+body.has-hero .site-main {
+  padding-top: 0;
+  min-height: calc(var(--vh) * 100);
+}
+
 .hero {
   width: var(--frame-width);
-  margin: clamp(16px, 4vw, 32px) auto 0;
+  margin: 0 auto clamp(16px, 4vw, 32px);
   position: relative;
   min-height: calc(var(--vh) * 100 - var(--nav-h));
   border-radius: 20px;
-  overflow: hidden;
+  overflow: visible;
   border: 1px solid rgba(255, 255, 255, 0.18);
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.35);
+}
+
+body.has-hero .hero {
+  min-height: calc(var(--vh) * 100);
 }
 
 .hero__bg {
@@ -181,6 +191,14 @@ body.home .hero__bg {
   background: linear-gradient(180deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.4) 65%, rgba(0, 0, 0, 0) 100%);
   pointer-events: none;
   z-index: 1;
+  border-radius: inherit;
+}
+
+.hero__menu {
+  position: absolute;
+  top: calc(env(safe-area-inset-top, 0px) + clamp(12px, 2.8vw, 16px));
+  left: calc(env(safe-area-inset-left, 0px) + clamp(12px, 2.8vw, 16px));
+  z-index: 3;
 }
 
 .hero__banner {
@@ -345,40 +363,4 @@ body.home .hero__bg {
     animation: none !important;
     transition: none !important;
   }
-}
-/* === UNIVERSAL TOP SPACING FIX === */
-
-/* Remove any default page spacing */
-html, body {
-  margin: 0 !important;
-  padding: 0 !important;
-}
-
-/* Logo pill container — small top margin only */
-.site-bar {
-  margin: 6px auto 0 !important;   /* bring header closer to top */
-  padding: 0 10px !important;
-  justify-content: flex-start !important;  /* keep left-aligned; change to center if desired */
-}
-
-/* Kill hidden padding/margins on the first section/wrapper */
-main, .page, .wrap, .container, .content, .section:first-child {
-  margin-top: 0 !important;
-  padding-top: 0 !important;
-}
-
-/* Ensure the hero block sits just under the pill with a tiny frame */
-.hero, .masthead, .card-hero, .section-hero {
-  margin-top: 8px !important;
-}
-
-/* Prevent image-based heroes from adding extra gap */
-.hero img, .masthead img, .card-hero img, .section-hero img {
-  display: block;
-}
-
-/* Desktop should behave the same as mobile */
-@media (min-width: 768px) {
-  .site-bar { margin-top: 6px !important; }
-  .hero, .masthead, .card-hero, .section-hero { margin-top: 8px !important; }
 }


### PR DESCRIPTION
## Summary
- capture the brand navigation markup so hero pages can render the pill directly over the hero while non-hero pages keep the fixed header
- update hero/layout styles to remove the top spacing, anchor the pill inside the hero with safe-area offsets, and add a subtle shadow for readability

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not installed in environment)*
- `bundle install` *(fails: unable to download gems – 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d2913879708325a2b8f3350a6d2dfa