### PR TITLE
Set Jekyll `baseurl` for project-site deployment and remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-black-hive.com

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,9 @@
 title: STONE & ANVIL
 description: Recycled Silver • Handcrafted Jewellery
 url: ""
-baseurl: ""
+# GitHub Pages project sites are served from /<repo-name>/.
+# Keeping baseurl explicit prevents broken asset/link paths when no custom domain is used.
+baseurl: "/BLACK-HIVE"
 collections:
   products:
     output: true


### PR DESCRIPTION
### Motivation
- Fix broken asset and navigation paths after the custom domain was removed so the Jekyll site serves correctly from the repository subpath (`/BLACK-HIVE`) on GitHub Pages.

### Description
- Update `_config.yml` to set `baseurl: "/BLACK-HIVE"` (with comments explaining why) and remove the `CNAME` file so the site no longer depends on a custom domain and `relative_url`-generated links resolve to the repository path.

### Testing
- Verified templates use `relative_url` with `rg`, then attempted `bundle exec jekyll build` and `bundle install` to validate a local build but both operations could not complete due to RubyGems network/permission errors (HTTP 403), so local automated build verification was not possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ee88cc5083258e34651d46472516)