### PR TITLE
Clear Jekyll `baseurl` for root-domain GitHub Pages hosting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 title: STONE & ANVIL
 description: Recycled Silver • Handcrafted Jewellery
 url: ""
-# GitHub Pages project sites are served from /<repo-name>/.
-# Keeping baseurl explicit prevents broken asset/link paths when no custom domain is used.
-baseurl: "/BLACK-HIVE"
+# User/organization GitHub Pages sites are served from the root domain.
+# Leave baseurl empty so assets resolve on https://<user>.github.io without a custom domain.
+baseurl: ""
 collections:
   products:
     output: true


### PR DESCRIPTION
### Motivation
- Fix broken/unstyled site rendering caused by generated asset URLs including a repository `baseurl` when the site is served from a root GitHub Pages domain.

### Description
- Update `_config.yml` to change `baseurl` from `"/BLACK-HIVE"` to `""` and clarify the inline comment so assets and links resolve correctly on `https://<user>.github.io`.

### Testing
- Attempted to run `bundle exec jekyll build` to validate output paths, but the build could not run in this environment due to the missing `jekyll` executable (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ef6c4e7883258ba09447838b3725)