### PR TITLE
Set Jekyll `baseurl` to /BLACK-HIVE to fix missing styles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 title: STONE & ANVIL
 description: Recycled Silver • Handcrafted Jewellery
 url: ""
-# User/organization GitHub Pages sites are served from the root domain.
-# Leave baseurl empty so assets resolve on https://<user>.github.io without a custom domain.
-baseurl: ""
+# Project GitHub Pages sites are served from /<repo-name>.
+# Set baseurl to the repository name so CSS/assets resolve in production.
+baseurl: "/BLACK-HIVE"
 collections:
   products:
     output: true


### PR DESCRIPTION
### Motivation
- The project site was loading assets from the domain root which caused missing CSS/images and an unstyled, clunky UI, so the `baseurl` needs to be set for GitHub Pages project hosting.

### Description
- Updated `_config.yml` to change `baseurl` from an empty string to `"/BLACK-HIVE"` and revised the surrounding comments to document project-site hosting behavior.

### Testing
- Verified the updated `baseurl` is present in `_config.yml`, and attempted `bundle exec jekyll build` but a full local build could not be run because the environment lacks the `jekyll` executable (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f0cf4234832583b5cccae87e071f)