### PR TITLE
Fix GitHub Pages asset loading by using root baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,8 @@
 title: STONE & ANVIL
 description: Recycled Silver • Handcrafted Jewellery
-url: ""
-# Project GitHub Pages sites are served from /<repo-name>.
-# Set baseurl to the repository name so CSS/assets resolve in production.
-baseurl: "/BLACK-HIVE"
+url: "https://on123-hub.github.io"
+# User/organization GitHub Pages sites are served from the domain root.
+baseurl: ""
 collections:
   products:
     output: true


### PR DESCRIPTION
### Motivation
- The site is a Jekyll-based user/organization Pages site and assets were generated with a project-site `baseurl`, causing CSS/JS/assets to resolve to paths like `/BLACK-HIVE/...` which 404 on `https://on123-hub.github.io/`. 

### Description
- Updated `_config.yml` to set `url: "https://on123-hub.github.io"` and `baseurl: ""` so generated links resolve from the domain root. 
- Replaced the old project-site guidance comment with a user/org Pages note to avoid future confusion. 
- No template, asset, or CNAME changes were made; templates already use `relative_url` so the `baseurl` change fixes stylesheet, image and navigation paths globally.

### Testing
- Inspected repository files and templates (checked `_config.yml`, `_layouts/default.html`, `_includes/header.html`, and `relative_url` usage) and confirmed paths are produced via `relative_url` which relies on `baseurl`. 
- Attempted `bundle install`, which failed due to upstream Rubygems `403 Forbidden` so a local `jekyll build` could not be executed in this environment. 
- Verified by static inspection that after the config change the site will reference files like `
/style.css
` and `/assets/logo.svg` (root-relative) rather than `/BLACK-HIVE/...`, which resolves the broken asset loading symptom.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5f1e3685c832586e63006337586bf)